### PR TITLE
feat: add request dto for estado turno

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.imb2025.smedico.dto.EstadoTurnoDTO;
 import com.imb2025.smedico.dto.EstadoTurnoRequestDTO;
 import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.service.IEstadoTurnoService;
@@ -37,8 +36,8 @@ public class EstadoTurnoController {
 
     // POST de EstadoTurnoE (Crear un nuevo registro)
     @PostMapping
-    public EstadoTurno create(@RequestBody EstadoTurnoDTO dto) {
-        EstadoTurno entidad = EstadoTurnoDTO.fromDto(dto);
+    public EstadoTurno create(@RequestBody EstadoTurnoRequestDTO dto) {
+        EstadoTurno entidad = IEstadoTurnoService.fromDto(dto);
         return estadoTurnoService.create(entidad);
     }
 
@@ -58,9 +57,9 @@ public class EstadoTurnoController {
     
     @PutMapping("/{id}")
     public ResponseEntity<EstadoTurno> update(@PathVariable Long id, @RequestBody EstadoTurnoRequestDTO dto) {
-        EstadoTurno estadoTurno = EstadoTurnoRequestDTO.fromDto(dto);
+        EstadoTurno estadoTurno = IEstadoTurnoService.fromDto(dto);
         EstadoTurno actualizado = estadoTurnoService.update(id, estadoTurno);
-        
+
         return ResponseEntity.ok(actualizado);
     }
 

--- a/src/main/java/com/imb2025/smedico/dto/EstadoTurnoRequestDTO.java
+++ b/src/main/java/com/imb2025/smedico/dto/EstadoTurnoRequestDTO.java
@@ -1,0 +1,20 @@
+package com.imb2025.smedico.dto;
+
+public class EstadoTurnoRequestDTO {
+    private String nombre;
+
+    public EstadoTurnoRequestDTO() {
+    }
+
+    public EstadoTurnoRequestDTO(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+}

--- a/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
@@ -3,7 +3,7 @@ package com.imb2025.smedico.service;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.EstadoTurnoDTO;
+import com.imb2025.smedico.dto.EstadoTurnoRequestDTO;
 import com.imb2025.smedico.entity.EstadoTurno;
 @Service
 
@@ -17,6 +17,12 @@ public interface IEstadoTurnoService {
     public EstadoTurno update(Long id, EstadoTurno estadoTurno); // actualiza un estado segun su id
 
     public  void deleteById(Long id); // elimina un registro poe id
+
+    static EstadoTurno fromDto(EstadoTurnoRequestDTO dto) {
+        EstadoTurno estadoTurno = new EstadoTurno();
+        estadoTurno.setNombre(dto.getNombre());
+        return estadoTurno;
+    }
 	
 
 }

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoImpl.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.EstadoTurnoDTO;
 import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.repository.EstadoTurnoRepository;
 import com.imb2025.smedico.service.IEstadoTurnoService;


### PR DESCRIPTION
## Summary
- add dedicated request DTO for EstadoTurno
- convert EstadoTurno requests to entities via service helper
- update controller to use EstadoTurnoRequestDTO

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_688fa2f814d0832fac0fd2ed5ff20500