### PR TITLE
Return ResponseEntity from EstadoTurnoController methods

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
@@ -24,21 +24,30 @@ public class EstadoTurnoController {
 
     // GET de EstadoTurnoE (Obtener todos los registros por lista)
     @GetMapping
-    public List<EstadoTurno> getAll() {
-        return estadoTurnoService.findAll();
+    public ResponseEntity<List<EstadoTurno>> getAll() {
+        List<EstadoTurno> estados = estadoTurnoService.findAll();
+        if (estados.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(estados);
     }
 
     // GET de EstadoTurnoE {id} (Obtener un registro por ID)
     @GetMapping("/{id}")
-    public EstadoTurno getById(@PathVariable Long id) {
-        return estadoTurnoService.findById(id); // Devuelve el objeto o null si no existe
+    public ResponseEntity<EstadoTurno> getById(@PathVariable Long id) {
+        EstadoTurno estadoTurno = estadoTurnoService.findById(id); // Devuelve el objeto o null si no existe
+        if (estadoTurno == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(estadoTurno);
     }
 
     // POST de EstadoTurnoE (Crear un nuevo registro)
     @PostMapping
-    public EstadoTurno create(@RequestBody EstadoTurnoRequestDTO dto) {
+    public ResponseEntity<EstadoTurno> create(@RequestBody EstadoTurnoRequestDTO dto) {
         EstadoTurno entidad = IEstadoTurnoService.fromDto(dto);
-        return estadoTurnoService.create(entidad);
+        EstadoTurno creado = estadoTurnoService.create(entidad);
+        return ResponseEntity.status(HttpStatus.CREATED).body(creado);
     }
 
     /*Con ExceptionHandler interceptamos la excepcion, se crea el map que es una estructura_
@@ -67,25 +76,20 @@ public class EstadoTurnoController {
 
     
     @DeleteMapping("/{id}")
- /*Entrás al try.
-Verificás si el ID existe.
-Si no existe, lanza la excepción manualmente con throw new Exception(...).
-Esa excepción es capturada por el catch.
-El catch arma una respuesta clara: por ejemplo, un mensaje tipo
- "Error: No se encontró el ID" (texto o JSON)*/
-    
-    public String delete(@PathVariable Long id) {
-        try {
-            // Forzar una excepción si no existe el ID
-            if (estadoTurnoService.findById(id) == null) {
-                throw new Exception("No se encontró el EstadoTurno con ID: " + id);
-            }
+    /*Entrás al try.
+    Verificás si el ID existe.
+    Si no existe, lanza la excepción manualmente con throw new Exception(...).
+    Esa excepción es capturada por el catch.
+    El catch arma una respuesta clara: por ejemplo, un mensaje tipo
+     "Error: No se encontró el ID" (texto o JSON)*/
 
-            estadoTurnoService.deleteById(id);
-            return "Eliminado correctamente";
-        } catch (Exception e) {
-            return "Error: " + e.getMessage();
+    public ResponseEntity<String> delete(@PathVariable Long id) {
+        if (estadoTurnoService.findById(id) == null) {
+            return ResponseEntity.badRequest()
+                    .body("Error: No se encontró el EstadoTurno con ID: " + id);
         }
+        estadoTurnoService.deleteById(id);
+        return ResponseEntity.ok("Eliminado correctamente");
     }
 
 }


### PR DESCRIPTION
## Summary
- Wrap CRUD operations in `EstadoTurnoController` with `ResponseEntity` to provide proper HTTP status codes for list, detail, creation and deletion endpoints.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fa52388dc832fa46f62d98bbda4b8