### PR TITLE
Add existence check and robust error handling for EstadoTurno

### DIFF
--- a/src/main/java/com/imb2025/smedico/exception/EstadoTurnoNotFoundException.java
+++ b/src/main/java/com/imb2025/smedico/exception/EstadoTurnoNotFoundException.java
@@ -1,0 +1,12 @@
+package com.imb2025.smedico.exception;
+
+/**
+ * Excepción personalizada para indicar que un EstadoTurno no existe.
+ */
+public class EstadoTurnoNotFoundException extends RuntimeException {
+
+    public EstadoTurnoNotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
@@ -18,6 +18,8 @@ public interface IEstadoTurnoService {
 
     public  void deleteById(Long id); // elimina un registro poe id
 
+    public boolean existsById(Long id);
+
     static EstadoTurno fromDto(EstadoTurnoRequestDTO dto) {
         EstadoTurno estadoTurno = new EstadoTurno();
         estadoTurno.setNombre(dto.getNombre());

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoImpl.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Service;
 
 import com.imb2025.smedico.entity.EstadoTurno;
+import com.imb2025.smedico.exception.EstadoTurnoNotFoundException;
 import com.imb2025.smedico.repository.EstadoTurnoRepository;
 import com.imb2025.smedico.service.IEstadoTurnoService;
 
@@ -33,29 +34,47 @@ public class EstadoTurnoImpl implements IEstadoTurnoService { //indicamos que la
 
     @Override
     public EstadoTurno create(EstadoTurno estadoTurno) {
-        return estadoTurnoRepository.save(estadoTurno);
+        try {
+            return estadoTurnoRepository.save(estadoTurno);
+        } catch (Exception e) {
+            throw new RuntimeException("Error al crear el EstadoTurno", e);
+        }
     }
 
 //incorporamos en el metodo que verifique si el id que se busca en update existe o no
     @Override
     public EstadoTurno update(Long id, EstadoTurno estadoTurno) {
-        Optional<EstadoTurno> existente = estadoTurnoRepository.findById(id);
+        try {
+            Optional<EstadoTurno> existente = estadoTurnoRepository.findById(id);
 
-        if (existente.isPresent()) {
-            EstadoTurno actualizado = existente.get();
-            
-            //  Asegurarse de que se actualiza el nombre antes de guardar
-            actualizado.setNombre(estadoTurno.getNombre());
+            if (existente.isPresent()) {
+                EstadoTurno actualizado = existente.get();
 
-            return estadoTurnoRepository.save(actualizado);
-        } else {
-            throw new RuntimeException("EstadoTurno con id " + id + " no existe");
+                //  Asegurarse de que se actualiza el nombre antes de guardar
+                actualizado.setNombre(estadoTurno.getNombre());
+
+                return estadoTurnoRepository.save(actualizado);
+            } else {
+                throw new EstadoTurnoNotFoundException("EstadoTurno con id " + id + " no existe");
+            }
+        } catch (EstadoTurnoNotFoundException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Error al actualizar el EstadoTurno con id " + id, e);
         }
     }
 
     @Override
     public void deleteById(Long id) { //eliminamos un registro segun su ID
+        if (!estadoTurnoRepository.existsById(id)) {
+            throw new EstadoTurnoNotFoundException("EstadoTurno con id " + id + " no existe");
+        }
         estadoTurnoRepository.deleteById(id);
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return estadoTurnoRepository.existsById(id);
     }
 }
 


### PR DESCRIPTION
## Summary
- expose `existsById` in `IEstadoTurnoService`
- add try-catch around create/update and use custom `EstadoTurnoNotFoundException`
- validate ID existence before delete

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fa914c210832f8286fd5c096fd622