### PR TITLE
Add one-to-many relationship in EstadoTurno

### DIFF
--- a/src/main/java/com/imb2025/smedico/entity/EstadoTurno.java
+++ b/src/main/java/com/imb2025/smedico/entity/EstadoTurno.java
@@ -4,6 +4,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
 
 @Entity
 public class EstadoTurno {
@@ -12,6 +15,9 @@ public class EstadoTurno {
     @GeneratedValue(strategy = GenerationType.IDENTITY) // Generación automática del ID
     private Long id;
     private String nombre;
+
+    @OneToMany(mappedBy = "estadoTurno")
+    private List<Turno> turnos;
 
     // Getters
     public Long getId() {
@@ -22,6 +28,10 @@ public class EstadoTurno {
         return nombre;
     }
 
+    public List<Turno> getTurnos() {
+        return turnos;
+    }
+
     // Setters
     public void setId(Long id) {
         this.id = id;
@@ -29,6 +39,10 @@ public class EstadoTurno {
 
     public void setNombre(String nombre) {
         this.nombre = nombre;
+    }
+
+    public void setTurnos(List<Turno> turnos) {
+        this.turnos = turnos;
     }
 }
 


### PR DESCRIPTION
## Summary
- map EstadoTurno to its Turnos via `@OneToMany`
- add getter and setter for the associated Turnos

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688faa63bdac832fbf7ab417cd3deb05