### PR TITLE
Use No Content for missing EstadoTurno

### DIFF
--- a/docs/estado_turno.md
+++ b/docs/estado_turno.md
@@ -1,0 +1,10 @@
+# EstadoTurno API
+
+## GET /EstadoTurnoE/{id}
+
+Obtiene un EstadoTurno por su identificador.
+
+### Respuestas
+
+- **200 OK**: EstadoTurno encontrado y devuelto en el cuerpo de la respuesta.
+- **204 No Content**: No existe un EstadoTurno con el `id` especificado.

--- a/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
@@ -31,11 +31,13 @@ public class EstadoTurnoController {
     }
 
     // GET de EstadoTurnoE {id} (Obtener un registro por ID)
+    // Devuelve 204 (No Content) si el ID solicitado no existe
     @GetMapping("/{id}")
     public ResponseEntity<EstadoTurno> getById(@PathVariable Long id) {
         EstadoTurno estadoTurno = estadoTurnoService.findById(id); // Devuelve el objeto o null si no existe
         if (estadoTurno == null) {
-            return ResponseEntity.notFound().build();
+            // Se devuelve 204 en lugar de 404 para indicar ausencia de contenido
+            return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(estadoTurno);
     }


### PR DESCRIPTION
## Summary
- Return HTTP 204 when an EstadoTurno ID is not found
- Document EstadoTurno endpoint responses

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.imb2025:smedico:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 (absent))*

------
https://chatgpt.com/codex/tasks/task_e_688faccfce5c832f80d52dbfd7c93f00