### PR TITLE
Use HTTP 200 for EstadoTurno creation

### DIFF
--- a/docs/estado_turno.md
+++ b/docs/estado_turno.md
@@ -1,5 +1,13 @@
 # EstadoTurno API
 
+## POST /EstadoTurnoE
+
+Crea un nuevo EstadoTurno.
+
+### Respuestas
+
+- **200 OK**: EstadoTurno creado y devuelto en el cuerpo de la respuesta.
+
 ## GET /EstadoTurnoE/{id}
 
 Obtiene un EstadoTurno por su identificador.

--- a/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
@@ -47,7 +47,7 @@ public class EstadoTurnoController {
     public ResponseEntity<EstadoTurno> create(@RequestBody EstadoTurnoRequestDTO dto) {
         EstadoTurno entidad = IEstadoTurnoService.fromDto(dto);
         EstadoTurno creado = estadoTurnoService.create(entidad);
-        return ResponseEntity.status(HttpStatus.CREATED).body(creado);
+        return ResponseEntity.ok(creado);
     }
 
     /*Con ExceptionHandler interceptamos la excepcion y retornamos el mensaje*/


### PR DESCRIPTION
## Summary
- return EstadoTurno creations with HTTP 200 OK instead of 201
- document POST /EstadoTurnoE response as 200 OK

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688fb4306a68832fbe45f544dd07f7c6