### PR TITLE
Rename Encuesta entity to EncuestaSatisfaccion

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.imb2025.smedico.dto.EncuestaRequestDTO;
-import com.imb2025.smedico.entity.Encuesta;
+import com.imb2025.smedico.entity.EncuestaSatisfaccion;
 import com.imb2025.smedico.service.IEncuestaService;
 
 
@@ -28,8 +28,8 @@ import com.imb2025.smedico.service.IEncuestaService;
         private IEncuestaService service;
 
         @GetMapping
-        public ResponseEntity<List<Encuesta>> getAllEncuesta() {
-            List <Encuesta> encuesta = service.findAll();
+        public ResponseEntity<List<EncuestaSatisfaccion>> getAllEncuesta() {
+            List <EncuestaSatisfaccion> encuesta = service.findAll();
         	
         	return encuesta.isEmpty()
         			? ResponseEntity.noContent().build()
@@ -37,7 +37,7 @@ import com.imb2025.smedico.service.IEncuestaService;
         }
 
         @GetMapping("/{id}")
-        public ResponseEntity<Encuesta> getEncuestaById(@PathVariable Long id) {
+        public ResponseEntity<EncuestaSatisfaccion> getEncuestaById(@PathVariable Long id) {
            
         	return service.existsById(id)
             		
@@ -47,17 +47,17 @@ import com.imb2025.smedico.service.IEncuestaService;
 
         //Nuevo método POST
         @PostMapping
-        public ResponseEntity<Encuesta> createEncuesta(@RequestBody EncuestaRequestDTO dto) throws Exception {
-        	Encuesta encuesta = service.fromDto(dto);
+        public ResponseEntity<EncuestaSatisfaccion> createEncuesta(@RequestBody EncuestaRequestDTO dto) throws Exception {
+                EncuestaSatisfaccion encuesta = service.fromDto(dto);
                 return ResponseEntity.ok(service.create(encuesta));
             
         }
 
         //Nuevo método PUT
         @PutMapping("/{id}")
-        public ResponseEntity<Encuesta> update(@PathVariable Long id, @RequestBody EncuestaRequestDTO dto) throws Exception {
-               
-        	    Encuesta encuesta = service.fromDto(dto);
+        public ResponseEntity<EncuestaSatisfaccion> update(@PathVariable Long id, @RequestBody EncuestaRequestDTO dto) throws Exception {
+
+                    EncuestaSatisfaccion encuesta = service.fromDto(dto);
                 return ResponseEntity.ok(service.update(id, encuesta));
             
                 

--- a/src/main/java/com/imb2025/smedico/entity/EncuestaSatisfaccion.java
+++ b/src/main/java/com/imb2025/smedico/entity/EncuestaSatisfaccion.java
@@ -9,7 +9,7 @@ import jakarta.persistence.ManyToOne;
 
 
 @Entity
-public class Encuesta {
+public class EncuestaSatisfaccion {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,11 +28,11 @@ public class Encuesta {
 
 
     //Constructores
-	public Encuesta() {
+        public EncuestaSatisfaccion() {
 
 	}
 
-	public Encuesta(Long id, Paciente paciente, Consulta consulta, int puntaje, String comentario) {
+        public EncuestaSatisfaccion(Long id, Paciente paciente, Consulta consulta, int puntaje, String comentario) {
 		super();
 		this.id = id;
 		this.paciente = paciente;

--- a/src/main/java/com/imb2025/smedico/repository/EncuestaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/EncuestaRepository.java
@@ -2,8 +2,7 @@ package com.imb2025.smedico.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.imb2025.smedico.entity.Encuesta;
-
-public interface EncuestaRepository extends JpaRepository<Encuesta, Long> {
+import com.imb2025.smedico.entity.EncuestaSatisfaccion;
+public interface EncuestaRepository extends JpaRepository<EncuestaSatisfaccion, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/service/IEncuestaService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEncuestaService.java
@@ -3,17 +3,17 @@ package com.imb2025.smedico.service;
 import java.util.List;
 
 import com.imb2025.smedico.dto.EncuestaRequestDTO;
-import com.imb2025.smedico.entity.Encuesta;
+import com.imb2025.smedico.entity.EncuestaSatisfaccion;
 
 
     public interface IEncuestaService {
-        public List<Encuesta> findAll();
-        public Encuesta findById(Long id);
-        public Encuesta create(Encuesta encuesta);
-        public Encuesta update(Long id, Encuesta encuesta) throws Exception;
-        public Encuesta fromDto(EncuestaRequestDTO dto) throws Exception;
+        public List<EncuestaSatisfaccion> findAll();
+        public EncuestaSatisfaccion findById(Long id);
+        public EncuestaSatisfaccion create(EncuestaSatisfaccion encuesta);
+        public EncuestaSatisfaccion update(Long id, EncuestaSatisfaccion encuesta) throws Exception;
+        public EncuestaSatisfaccion fromDto(EncuestaRequestDTO dto) throws Exception;
         public void deleteById(Long id);
-		public boolean existsById(Long id);
+                public boolean existsById(Long id);
 
 
 

--- a/src/main/java/com/imb2025/smedico/service/jpa/EncuestaServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EncuestaServiceImpl.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 import com.imb2025.smedico.dto.EncuestaRequestDTO;
 import com.imb2025.smedico.entity.Consulta;
-import com.imb2025.smedico.entity.Encuesta;
+import com.imb2025.smedico.entity.EncuestaSatisfaccion;
 import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.repository.ConsultaRepository;
 import com.imb2025.smedico.repository.EncuestaRepository;
@@ -25,22 +25,22 @@ import com.imb2025.smedico.service.IEncuestaService;
         private ConsultaRepository consultaRepo;
 
         @Override
-        public List<Encuesta> findAll() {
+        public List<EncuestaSatisfaccion> findAll() {
             return repo.findAll();
         }
 
         @Override
-        public Encuesta findById(Long id) {
+        public EncuestaSatisfaccion findById(Long id) {
             return repo.findById(id).orElseThrow(() -> new RuntimeException("Encuesta no encontrada") ) ;
         }
         
-        public Encuesta create(Encuesta encuesta) {
-        	return repo.save(encuesta);
+        public EncuestaSatisfaccion create(EncuestaSatisfaccion encuesta) {
+                return repo.save(encuesta);
         }
        
 
         @Override
-        public Encuesta update(Long id, Encuesta encuesta) throws Exception{
+        public EncuestaSatisfaccion update(Long id, EncuestaSatisfaccion encuesta) throws Exception{
             if(repo.existsById(id)){
                 encuesta.setId(id);
                 return repo.save(encuesta);
@@ -53,13 +53,13 @@ import com.imb2025.smedico.service.IEncuestaService;
        
 
         @Override
-        public Encuesta fromDto(EncuestaRequestDTO dto) throws Exception{
+        public EncuestaSatisfaccion fromDto(EncuestaRequestDTO dto) throws Exception{
             Paciente paciente = pacienteRepo.findById(dto.getPacienteId())
                     .orElseThrow(() -> new Exception("Paciente no encontrado"));
             Consulta consulta = consultaRepo.findById(dto.getConsultaId())
                     .orElseThrow(() -> new Exception("Consulta no encontrada"));
             
-            Encuesta encuesta = new Encuesta();
+            EncuestaSatisfaccion encuesta = new EncuestaSatisfaccion();
             encuesta.setPaciente(paciente);
             encuesta.setConsulta(consulta);
             encuesta.setPuntaje(dto.getPuntaje());


### PR DESCRIPTION
## Summary
- Rename `Encuesta` entity to `EncuestaSatisfaccion`
- Update controller, service layer, and repository to use the new entity name

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6898977d2b0c832fae99b2231f182de5