### PR TITLE
refactor: standardize repository interfaces

### DIFF
--- a/src/main/java/com/imb2025/smedico/repository/AsistenteRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/AsistenteRepository.java
@@ -1,8 +1,9 @@
 package com.imb2025.smedico.repository;
-//Repositorio
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.imb2025.smedico.entity.Asistente;
 
-public interface AsistenteRepository extends JpaRepository<Asistente, Long>{
-	
+public interface AsistenteRepository extends JpaRepository<Asistente, Long> {
+
 }

--- a/src/main/java/com/imb2025/smedico/repository/ConsultaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/ConsultaRepository.java
@@ -1,9 +1,8 @@
 package com.imb2025.smedico.repository;
 
-
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.Consulta;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ConsultaRepository extends JpaRepository<Consulta, Long> {
 }

--- a/src/main/java/com/imb2025/smedico/repository/ConsultorioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/ConsultorioRepository.java
@@ -4,7 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.imb2025.smedico.entity.Consultorio;
 
 public interface ConsultorioRepository extends JpaRepository<Consultorio, Long> {
-	
-	
-	
+
 }

--- a/src/main/java/com/imb2025/smedico/repository/DetalleFacturaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/DetalleFacturaRepository.java
@@ -7,10 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.DetalleFactura;
 
+public interface DetalleFacturaRepository extends JpaRepository<DetalleFactura, Long> {
 
-
-public interface DetalleFacturaRepositories extends JpaRepository<DetalleFactura, Long> {
-    
-
-
-};
+}

--- a/src/main/java/com/imb2025/smedico/repository/DetalleRecetaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/DetalleRecetaRepository.java
@@ -1,14 +1,9 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.DetalleReceta;
-import com.imb2025.smedico.entity.Receta;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.imb2025.smedico.entity.DetalleReceta;
+
 public interface DetalleRecetaRepository extends JpaRepository<DetalleReceta, Long> {
-
-
-	public interface RecetaRepository extends JpaRepository<Receta, Long> {
-	}
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/DiagnosticoRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/DiagnosticoRepository.java
@@ -1,7 +1,8 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.Diagnostico;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.imb2025.smedico.entity.Diagnostico;
 
 public interface DiagnosticoRepository extends JpaRepository<Diagnostico, Long> {
 }

--- a/src/main/java/com/imb2025/smedico/repository/DireccionPacienteRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/DireccionPacienteRepository.java
@@ -1,10 +1,9 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.DireccionPaciente;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import com.imb2025.smedico.entity.DireccionPaciente;
+
 public interface DireccionPacienteRepository extends JpaRepository<DireccionPaciente, Long> {
 }
 

--- a/src/main/java/com/imb2025/smedico/repository/EstadoTurnoRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/EstadoTurnoRepository.java
@@ -1,13 +1,9 @@
 package com.imb2025.smedico.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.imb2025.smedico.entity.EstadoTurno;
 
-@Repository
-public interface EstadoTurnoRepository extends JpaRepository<EstadoTurno, Long>{ 
-
+public interface EstadoTurnoRepository extends JpaRepository<EstadoTurno, Long> {
 
 }
 	

--- a/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
@@ -7,10 +7,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.Estudio;
 
-public interface EstudioRepository extends JpaRepository<Estudio,Long> {
+public interface EstudioRepository extends JpaRepository<Estudio, Long> {
+
     @EntityGraph(attributePaths = {
             "paciente", "medico", "especialidad", "obraSocial", "oredenEstudio", "resultadoEstudio"
-        })
-        List<Estudio> findAll();
-	 
+    })
+    List<Estudio> findAll();
+
 }

--- a/src/main/java/com/imb2025/smedico/repository/FacturaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/FacturaRepository.java
@@ -1,7 +1,8 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.Factura;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.imb2025.smedico.entity.Factura;
 
 public interface FacturaRepository extends JpaRepository<Factura, Long> {
 

--- a/src/main/java/com/imb2025/smedico/repository/HistorialPacienteRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/HistorialPacienteRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.HistorialPaciente;
 
-
 public interface HistorialPacienteRepository extends JpaRepository<HistorialPaciente, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/HorarioAtencionRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/HorarioAtencionRepository.java
@@ -1,11 +1,8 @@
 package com.imb2025.smedico.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
 import com.imb2025.smedico.entity.HorarioAtencion;
 
-@Repository
 public interface HorarioAtencionRepository extends JpaRepository<HorarioAtencion, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/MedicamentoRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/MedicamentoRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.Medicamento;
 
-public interface MedicamentoRepository extends JpaRepository<Medicamento, Long>{
+public interface MedicamentoRepository extends JpaRepository<Medicamento, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/MedicoRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/MedicoRepository.java
@@ -4,7 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.imb2025.smedico.entity.Medico;
 
 public interface MedicoRepository extends JpaRepository<Medico, Long> {
-	
-	
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/MedioPagoRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/MedioPagoRepository.java
@@ -1,8 +1,9 @@
 package com.imb2025.smedico.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.imb2025.smedico.entity.MedioPago;
 
-public interface MedioPagoRepository extends JpaRepository<MedioPago,Long> {
+public interface MedioPagoRepository extends JpaRepository<MedioPago, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/MotivoCancelacionRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/MotivoCancelacionRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.MotivoCancelacion;
 
-public interface MotivoCancelacionRepository extends JpaRepository<MotivoCancelacion,Long> {
+public interface MotivoCancelacionRepository extends JpaRepository<MotivoCancelacion, Long> {
 
 }

--- a/src/main/java/com/imb2025/smedico/repository/ObraSocialRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/ObraSocialRepository.java
@@ -1,10 +1,9 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.ObraSocial;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
+import com.imb2025.smedico.entity.ObraSocial;
+
 public interface ObraSocialRepository extends JpaRepository<ObraSocial, Long> {
 }
 

--- a/src/main/java/com/imb2025/smedico/repository/OrdenEstudioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/OrdenEstudioRepository.java
@@ -1,7 +1,10 @@
 package com.imb2025.smedico.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.imb2025.smedico.entity.OrdenEstudio;
 
 public interface OrdenEstudioRepository extends JpaRepository<OrdenEstudio, Long> {
+
 }
+

--- a/src/main/java/com/imb2025/smedico/repository/PacienteRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/PacienteRepository.java
@@ -1,7 +1,10 @@
 package com.imb2025.smedico.repository;
 
-import com.imb2025.smedico.entity.Paciente;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.imb2025.smedico.entity.Paciente;
+
 public interface PacienteRepository extends JpaRepository<Paciente, Long> {
+
 }
+

--- a/src/main/java/com/imb2025/smedico/repository/RecetaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/RecetaRepository.java
@@ -4,8 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.Receta;
 
-public interface RecetaRepository extends JpaRepository<Receta,Long>{
+public interface RecetaRepository extends JpaRepository<Receta, Long> {
 
-	
-	
 }

--- a/src/main/java/com/imb2025/smedico/repository/ResultadoEstudioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/ResultadoEstudioRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.imb2025.smedico.entity.ResultadoEstudio;
 
-public interface ResultadoEstudioRepository extends JpaRepository<ResultadoEstudio, Long>{
-
+public interface ResultadoEstudioRepository extends JpaRepository<ResultadoEstudio, Long> {
 
 }


### PR DESCRIPTION
## Summary
- standardize repository interface formatting and imports
- rename misnamed `DetalleFacturaRepository`
- remove embedded `RecetaRepository` and redundant annotations

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6898b25a0f8c832f9700d36dd2955849