### PR TITLE
Refactor Paciente controller to use DTOs

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/PacienteController.java
+++ b/src/main/java/com/imb2025/smedico/controller/PacienteController.java
@@ -31,14 +31,15 @@ public class PacienteController {
     public ResponseEntity<Paciente> getPacienteById(@PathVariable Long id) {
         Paciente paciente = pacienteService.findById(id);
         if (paciente == null) {
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
         return ResponseEntity.ok(paciente);
     }
 
     @PostMapping
-    public ResponseEntity<Paciente> createPaciente(@RequestBody Paciente paciente) {
-        Paciente nuevo = pacienteService.save(paciente);
+    public ResponseEntity<Paciente> createPaciente(@RequestBody PacienteRequestDto dto) {
+        Paciente entidad = pacienteService.fromDto(dto);
+        Paciente nuevo = pacienteService.create(entidad);
         return ResponseEntity.ok(nuevo);
     }
 
@@ -50,10 +51,9 @@ public class PacienteController {
         }
 
         try {
-            
+
             Paciente entidad = pacienteService.fromDto(dto);
-            entidad.setId(id);  
-            Paciente actualizado = pacienteService.updatePaciente(entidad);
+            Paciente actualizado = pacienteService.update(id, entidad);
             return ResponseEntity.ok(actualizado);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(e.getMessage());


### PR DESCRIPTION
## Summary
- Use PacienteRequestDto in create endpoint and persist via service.create
- Update endpoint delegates to service.update using DTO conversion
- Return 404 status when requested patient is missing

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b4e823324832fa6db6c648cbe1023