### PR TITLE
Refactor DetalleRecetaController DTO handling

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/DetalleRecetaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/DetalleRecetaController.java
@@ -36,7 +36,7 @@ public class DetalleRecetaController {
     @PostMapping
     public ResponseEntity<?> save(@RequestBody DetalleRecetaRequestDto dto) {
         try {
-            DetalleReceta nueva = service.saveFromDTO(dto);
+            DetalleReceta nueva = service.create(service.fromDto(dto));
             return ResponseEntity.status(HttpStatus.CREATED).body(nueva);
         } catch (Exception e) {
             e.printStackTrace();
@@ -48,7 +48,8 @@ public class DetalleRecetaController {
     @PutMapping("/{id}")
     public ResponseEntity<?> update(@PathVariable Long id, @RequestBody DetalleRecetaRequestDto dto) {
         try {
-            DetalleReceta actualizada = service.updateFromDTO(id, dto);
+            DetalleReceta entidad = service.fromDto(dto);
+            DetalleReceta actualizada = service.update(id, entidad);
             return ResponseEntity.ok(actualizada);
         } catch (IllegalArgumentException e) {
             // Se usa NOT_FOUND si el detalle o datos relacionados no existen
@@ -69,5 +70,10 @@ public class DetalleRecetaController {
         }
         service.deleteById(id);
         return ResponseEntity.noContent().build();  // 204 No Content para borrar OK
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
     }
 }


### PR DESCRIPTION
## Summary
- build DetalleReceta entity from DTO when creating
- update DetalleReceta by converting DTO then updating
- add generic exception handler returning bad request

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b52c9c50c832fb46b5b99b24fc0ec