### PR TITLE
Refactor MedioPago controller to use ResponseEntity and add delete endpoint

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/MedioPagoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/MedioPagoController.java
@@ -3,7 +3,10 @@ package com.imb2025.smedico.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,30 +30,51 @@ public class MedioPagoController {
 	    this.service = service;
 	}
 	
-	@GetMapping //("/")
-	public List<MedioPago>findAllMedioPago(){
-		return service.findAll(); 
-	}
-	
-	@GetMapping("/{idmediopago}")
-	public MedioPago findMedioPagoByid(@PathVariable("idmediopago") Long id) {
-		return service.findById(id); 
-	}
-	
-	@PostMapping //("/")
-    public MedioPago createMedioPago(@RequestBody MedioPagoRequestDto mediopagoDto) {
-		try {
-	        return service.createMedioPago(mediopagoDto);
-	    } catch (Exception e) {
-	        System.out.println("Error al crear MedioPago: " + e.getMessage());
-	        return null; 
-	    }
+    @GetMapping
+    public ResponseEntity<List<MedioPago>> findAllMedioPago() {
+            return ResponseEntity.ok(service.findAll());
     }
-	
-	@PutMapping 
-	public MedioPago updateMedioPago(@RequestBody MedioPago mediopago) {
-		return service.save(mediopago);
-	}
+
+    @GetMapping("/{idmediopago}")
+    public ResponseEntity<MedioPago> findMedioPagoByid(@PathVariable("idmediopago") Long id) {
+            MedioPago medioPago = service.findById(id);
+            if (medioPago == null) {
+                    return ResponseEntity.notFound().build();
+            }
+            return ResponseEntity.ok(medioPago);
+    }
+
+    @PostMapping
+    public ResponseEntity<MedioPago> createMedioPago(@RequestBody MedioPagoRequestDto mediopagoDto) {
+            MedioPago medioPago = service.fromDto(mediopagoDto);
+            MedioPago creado = service.create(medioPago);
+            return ResponseEntity.status(HttpStatus.CREATED).body(creado);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<MedioPago> updateMedioPago(@PathVariable Long id,
+                    @RequestBody MedioPagoRequestDto mediopagoDto) {
+            MedioPago medioPago = service.fromDto(mediopagoDto);
+            MedioPago actualizado = service.update(id, medioPago);
+            if (actualizado == null) {
+                    return ResponseEntity.notFound().build();
+            }
+            return ResponseEntity.ok(actualizado);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMedioPago(@PathVariable Long id) {
+            if (!service.existsById(id)) {
+                    return ResponseEntity.notFound().build();
+            }
+            service.deleteById(id);
+            return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<String> handleException(Exception e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
 	
 	
 }  


### PR DESCRIPTION
## Summary
- Wrap MedioPago endpoints in `ResponseEntity`
- Convert DTOs with `fromDto` before service calls
- Add `DELETE` endpoint and exception handler

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b5919e754832f9c8c076f468f60c7