### PR TITLE
Use create method for historial and return 404 when missing

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/HistorialPacienteController.java
+++ b/src/main/java/com/imb2025/smedico/controller/HistorialPacienteController.java
@@ -35,14 +35,14 @@ public class HistorialPacienteController {
         if (historial != null) {
             return ResponseEntity.ok(historial);
         } else {
-            return ResponseEntity.noContent().build(); // 204
+            return ResponseEntity.notFound().build();
         }
     }
 
  // POST - Crear un nuevo historial de paciente usando DTO
     @PostMapping
     public ResponseEntity<HistorialPaciente> createHistorialPaciente(@RequestBody HistorialPacienteRequestDto historialPacienteDto) throws Exception {
-        HistorialPaciente nuevo = service.save(service.fromDto(historialPacienteDto));
+        HistorialPaciente nuevo = service.create(service.fromDto(historialPacienteDto));
         return ResponseEntity.ok(nuevo); // 200 OK
     }
 


### PR DESCRIPTION
## Summary
- Use `service.create` when building a historial from DTOs
- Return `404 Not Found` when a historial lookup by id returns null

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b74b950d4832f90b6c294ea8a0f1e