### PR TITLE
Adjust DireccionPaciente endpoints to accept DTOs

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/DireccionPacienteController.java
+++ b/src/main/java/com/imb2025/smedico/controller/DireccionPacienteController.java
@@ -1,5 +1,6 @@
 package com.imb2025.smedico.controller;
 
+import com.imb2025.smedico.dto.DireccionPacienteRequestDto;
 import com.imb2025.smedico.entity.DireccionPaciente;
 import com.imb2025.smedico.service.IDireccionPacienteService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,15 +32,17 @@ public class DireccionPacienteController {
     }
 
     @PostMapping
-    public ResponseEntity<DireccionPaciente> create(@RequestBody DireccionPaciente direccion) throws Exception {
+    public ResponseEntity<DireccionPaciente> create(@RequestBody DireccionPacienteRequestDto direccionPacienteRequestDto) throws Exception {
+        DireccionPaciente direccion = direccionPacienteService.fromDto(direccionPacienteRequestDto);
         DireccionPaciente saved = direccionPacienteService.create(direccion);
         return ResponseEntity.ok(saved);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<DireccionPaciente> update(@PathVariable Long id,
-                                                    @RequestBody DireccionPaciente direccionPaciente) throws Exception {
-        DireccionPaciente updated = direccionPacienteService.update(id, direccionPaciente);
+                                                    @RequestBody DireccionPacienteRequestDto direccionPacienteRequestDto) throws Exception {
+        DireccionPaciente direccion = direccionPacienteService.fromDto(direccionPacienteRequestDto);
+        DireccionPaciente updated = direccionPacienteService.update(id, direccion);
         return ResponseEntity.ok(updated);
     }
 


### PR DESCRIPTION
## Summary
- Accept DireccionPacienteRequestDto in DireccionPacienteController's create and update endpoints
- Convert request DTOs to entities via `direccionPacienteService.fromDto`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM for com.imb2025:smedico:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_689b75d676e4832f8fffa0df19920279