### PR TITLE
Use service for EstadoTurno DTO conversion

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstadoTurnoController.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.imb2025.smedico.dto.EstadoTurnoDto;
 import com.imb2025.smedico.dto.EstadoTurnoRequestDto;
 import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.service.IEstadoTurnoService;
@@ -42,8 +41,8 @@ public class EstadoTurnoController {
 
     // POST de EstadoTurnoE (Crear un nuevo registro)
     @PostMapping
-    public ResponseEntity<EstadoTurno> create(@RequestBody EstadoTurnoDto dto) {
-        EstadoTurno entidad = EstadoTurnoDto.fromDto(dto);
+    public ResponseEntity<EstadoTurno> create(@RequestBody EstadoTurnoRequestDto dto) {
+        EstadoTurno entidad = estadoTurnoService.fromDto(dto);
         EstadoTurno creado = estadoTurnoService.create(entidad);
         return ResponseEntity.status(HttpStatus.CREATED).body(creado);
     }
@@ -64,9 +63,9 @@ public class EstadoTurnoController {
     
     @PutMapping("/{id}")
     public ResponseEntity<EstadoTurno> update(@PathVariable Long id, @RequestBody EstadoTurnoRequestDto dto) {
-        EstadoTurno estadoTurno = EstadoTurnoRequestDto.fromDto(dto);
+        EstadoTurno estadoTurno = estadoTurnoService.fromDto(dto);
         EstadoTurno actualizado = estadoTurnoService.update(id, estadoTurno);
-        
+
         return ResponseEntity.ok(actualizado);
     }
 


### PR DESCRIPTION
## Summary
- Convert EstadoTurno DTOs to entities using `estadoTurnoService.fromDto` in both create and update.
- Adjust create endpoint to accept `EstadoTurnoRequestDto` directly.

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689b83f0d4ec832f9934258936f60a54