### PR TITLE
Add global REST exception handler

### DIFF
--- a/src/main/java/com/imb2025/smedico/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/imb2025/smedico/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.imb2025.smedico.exception;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import com.imb2025.smedico.dto.ApiResponseErrorDto;
+import com.imb2025.smedico.dto.FieldErrorDto;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<ApiResponseErrorDto> handleResourceNotFoundException(ResourceNotFoundException ex) {
+        List<FieldErrorDto> errors = new ArrayList<>();
+        errors.add(new FieldErrorDto("error", ex.getMessage()));
+        ApiResponseErrorDto response = new ApiResponseErrorDto(false, errors);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponseErrorDto> handleGenericException(Exception ex) {
+        List<FieldErrorDto> errors = new ArrayList<>();
+        errors.add(new FieldErrorDto("error", ex.getMessage()));
+        ApiResponseErrorDto response = new ApiResponseErrorDto(false, errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `GlobalExceptionHandler` using `@RestControllerAdvice` to wrap `ResourceNotFoundException` and generic errors in `ApiResponseErrorDto`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... Network is unreachable)*
- `./mvnw -q test` *(fails: Permission denied)*
- `sh mvnw -q test` *(fails: cannot open mvnw/.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68a495d9765c832f8389af1a62f11cb6