### PR TITLE
TP04: Integración de Excepciones y DTO Genéricos

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/TurnoController.java
+++ b/src/main/java/com/imb2025/smedico/controller/TurnoController.java
@@ -3,6 +3,7 @@ package com.imb2025.smedico.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.imb2025.smedico.dto.ApiResponseSuccessDto;
 import com.imb2025.smedico.dto.TurnoRequestDto;
 import com.imb2025.smedico.entity.Turno;
 import com.imb2025.smedico.service.ITurnoService;
@@ -24,53 +26,68 @@ public class TurnoController {
     private ITurnoService service;
     
 
-
-    // GET - Obtener todos los turnos
+  
     @GetMapping("/turno")
-    public ResponseEntity<List<Turno>> findAllTurnos() {
-        List<Turno> lista = service.findAll();
+    public ResponseEntity<ApiResponseSuccessDto<List<Turno>>> findAllTurnos() {
+    	 List<Turno> lista = service.findAll();
+        ApiResponseSuccessDto<List<Turno>> resp;
         if (lista.isEmpty()) {
-            return ResponseEntity.noContent().build();
+            resp = new ApiResponseSuccessDto<>(true,"No hay turnos disponibles",lista);
+        }else {
+            resp = new ApiResponseSuccessDto<>(true,"Lista de turnos",lista);
         }
-        return ResponseEntity.ok(lista);
+        return ResponseEntity.ok(resp);
     }
+   
 
     // GET - Obtener turno por ID
-    @GetMapping("/turno/{idturno}")
-    public ResponseEntity<Turno> findTurnoById(@PathVariable("idturno") Long id) {
+    @GetMapping("turno/{idturno}")
+    public ResponseEntity<ApiResponseSuccessDto<Turno>> findTurnoById(@PathVariable("idturno") Long id) {
         Turno turno = service.findById(id);
         if (turno == null) {
-            return ResponseEntity.noContent().build();
+            ApiResponseSuccessDto<Turno> resp = new ApiResponseSuccessDto<>(false, "Turno no encontrado", null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(resp);
         }
-        return ResponseEntity.ok(turno);
+        ApiResponseSuccessDto<Turno> resp = new ApiResponseSuccessDto<>(true, "Turno encontrado", turno);
+        return ResponseEntity.ok(resp);
     }
 
+    // POST - Crear turno
     @PostMapping("/turno")
-    public ResponseEntity<Turno> create(@RequestBody TurnoRequestDto dto) throws Exception {
-        Turno turno = service.fromDto(dto);
-        return ResponseEntity.ok(service.create(turno));
+    public ResponseEntity<ApiResponseSuccessDto<Turno>>create(@RequestBody TurnoRequestDto dto) throws Exception {
+        Turno turno = service.create(service.fromDto(dto));
+        ApiResponseSuccessDto<Turno> resp = new ApiResponseSuccessDto<>(true,"Turno creado exitosamente",turno);
+        return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
-
-    @PutMapping("/turno/{idturno}")
-    public ResponseEntity<Turno> update(@PathVariable("idturno") Long idturno, @RequestBody TurnoRequestDto dto) throws Exception {
+ 
+    // PUT - Actualizar turno
+    @PutMapping("/{idturno}")
+    public ResponseEntity<ApiResponseSuccessDto<Turno>> update(@PathVariable("idturno") Long idturno,
+                                                               @RequestBody TurnoRequestDto dto) throws Exception {
         Turno turno = service.fromDto(dto);
-        return ResponseEntity.ok(service.update(idturno, turno));
+        Turno actualizado = service.update(idturno, turno);
+        ApiResponseSuccessDto<Turno> resp = new ApiResponseSuccessDto<>(true, "Turno actualizado correctamente", actualizado);
+        return ResponseEntity.ok(resp);
     }
 
     // DELETE - Eliminar turno
-    @DeleteMapping("/turno/{idturno}")
-    public ResponseEntity<String> deleteTurno(@PathVariable("idturno") Long id) {
+    @DeleteMapping("/{idturno}")
+    public ResponseEntity<ApiResponseSuccessDto<Void>> deleteTurno(@PathVariable("idturno") Long id) throws Exception {
+        Turno existente = service.findById(id);
+        if (existente == null) {
+            ApiResponseSuccessDto<Void> resp = new ApiResponseSuccessDto<>(false, "Turno no encontrado", null);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(resp);
+        }
+
         service.deleteById(id);
-        return ResponseEntity.ok("Turno " + id + " eliminado correctamente.");
+        ApiResponseSuccessDto<Void> resp = new ApiResponseSuccessDto<>(true, "Turno " + id + " eliminado correctamente", null);
+        return ResponseEntity.ok(resp);
     }
 
+    // Manejo de excepciones globales
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<String> handleException(Exception ex) {
-        return ResponseEntity.badRequest().body(ex.getMessage());
-
+    public ResponseEntity<ApiResponseSuccessDto<String>> handleException(Exception ex) {
+        ApiResponseSuccessDto<String> resp = new ApiResponseSuccessDto<>(false, ex.getMessage(), null);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(resp);
     }
-
- 
-    
-    
 }

--- a/src/main/java/com/imb2025/smedico/entity/Turno.java
+++ b/src/main/java/com/imb2025/smedico/entity/Turno.java
@@ -8,6 +8,8 @@ import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 @Entity
 public class Turno {
     @Id
@@ -23,6 +25,7 @@ public class Turno {
     private Medico medico;
 
     @ManyToOne
+    @JsonIgnoreProperties("turnos") // Ignora el campo "turnos" dentro de EstadoTurno al serializar
     private EstadoTurno estadoTurno;
 
     public Turno() {}

--- a/src/main/java/com/imb2025/smedico/service/jpa/TurnoServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/TurnoServiceImpl.java
@@ -8,6 +8,7 @@ import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.entity.Medico;
 import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.entity.Turno;
+import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.repository.EstadoTurnoRepository;
 import com.imb2025.smedico.repository.MedicoRepository;
 import com.imb2025.smedico.repository.PacienteRepository;
@@ -38,8 +39,9 @@ public class TurnoServiceImpl implements ITurnoService {
 
     @Override
     public Turno findById(Long id) {
-        return repo.findById(id)
-            .orElseThrow(() -> new RuntimeException("Turno con ID " + id + " no encontrado"));
+    	return repo.findById(id)
+    		    .orElseThrow(() -> new ResourceNotFoundException(
+    		        "Entidad no encontrada con id " + id));
     }
 
     @Override


### PR DESCRIPTION
Use @JsonIgnoreProperties("turnos") para evitar la serialización recursiva infinita.
El problema ocurre porque la entidad Turno tiene una relación con EstadoTurno y a su vez EstadoTurno contiene una lista de Turnos.
Al convertir a JSON, Jackson intenta recorrer ambas relaciones en forma cíclica 
(Turno → EstadoTurno → Turnos → EstadoTurno → ...), generando un bucle infinito y JSONs enormes.
No puedo modificar la entidad 'turnos' dentro de EstadoTurno porque pertenece a otro compañero.
Por eso apliqué la anotación en la relación desde Turno: indique que ignore la lista 'turnos' dentro de EstadoTurno al serializar un Turno.
Esta solución rompe el ciclo sin alterar la entidad de mi compañero y evita errores en la API.
Por lo que se debería corregir en la entidad EstadoTurno.