### PR TITLE
tp06-Lucero-Eduardo

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
@@ -3,48 +3,27 @@ package com.imb2025.smedico.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import com.imb2025.smedico.dto.ApiResponseSuccessDto;
 import com.imb2025.smedico.dto.EncuestaRequestDto;
 import com.imb2025.smedico.entity.Encuesta;
 import com.imb2025.smedico.service.IEncuestaService;
 
-import jakarta.validation.Valid;
-
-@RestController
-@RequestMapping("/api/encuestas")
-public class EncuestaController {
-
-    @Autowired
-    private IEncuestaService service;
 
 
-    @GetMapping
-    public ResponseEntity<List<Encuesta>> getAllEncuesta() {
-        List<Encuesta> encuesta = service.findAll();
-        return encuesta.isEmpty()
-                ? ResponseEntity.noContent().build()
-                : ResponseEntity.ok(encuesta);
-    }
-
-    @GetMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<Encuesta>> getEncuestaById(@PathVariable Long id) {
-        Encuesta data = service.findById(id);
-        ApiResponseSuccessDto<Encuesta> resp =
-                new ApiResponseSuccessDto<>(true, "Encuesta encontrada", data);
-        return ResponseEntity.ok(resp);
-    }
-
-    // POST con @Valid
-    @PostMapping
-    public ResponseEntity<Encuesta> createEncuesta(@Valid @RequestBody EncuestaRequestDto dto) throws Exception {
-        Encuesta encuesta = service.fromDto(dto);
-        Encuesta creada = service.create(encuesta);
-        return ResponseEntity.status(HttpStatus.CREATED).body(creada);
-    }
+    @RestController
+    @RequestMapping("/api/encuestas")
+    public class EncuestaController {
 
         @Autowired
         private IEncuestaService service;
@@ -90,22 +69,6 @@ public class EncuestaController {
 
 
 
-    // PUT con @Valid
-    @PutMapping("/{id}")
-    public ResponseEntity<Encuesta> update(@PathVariable Long id,
-                                           @Valid @RequestBody EncuestaRequestDto dto) throws Exception {
-        Encuesta encuesta = service.fromDto(dto);
-        return ResponseEntity.ok(service.update(id, encuesta));
-    }
-
- tp05-jordan-humberto
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long id) {
-        service.deleteById(id);
-        return ResponseEntity.ok().build();
-    }
-}
-
         @DeleteMapping("/{id}")
         public ResponseEntity<Void> deleteById(@PathVariable Long id) {
             service.deleteById(id);
@@ -115,4 +78,3 @@ public class EncuestaController {
         
 
     }
-

--- a/src/main/java/com/imb2025/smedico/controller/EstudioController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstudioController.java
@@ -7,7 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.imb2025.smedico.dto.ApiResponseSuccessDto;
 import com.imb2025.smedico.dto.EstudioRequestDto;
 import com.imb2025.smedico.dto.EstudioResponseDto;
 import com.imb2025.smedico.entity.Estudio;
@@ -22,84 +21,55 @@ public class EstudioController {
     @Autowired
     private IEstudioService service;
 
+    
     @GetMapping
-    public ResponseEntity<?> findAll() {
+    public ResponseEntity<List<EstudioResponseDto>> findAll() {
         List<Estudio> lista = service.findAll();
-        if (lista.isEmpty()) {
-            return ResponseEntity.noContent().build(); // 204 sin body
+        if (lista == null || lista.isEmpty()) {
+            return ResponseEntity.noContent().build();
         }
         List<EstudioResponseDto> dtoList = lista.stream()
-                .map(EstudioResponseDto::new)
+                .map(EstudioResponseDto::new) 
                 .collect(Collectors.toList());
-
-        ApiResponseSuccessDto<List<EstudioResponseDto>> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Listado de estudios (DTO)",
-                dtoList
-        );
-        return ResponseEntity.ok(resp); // 200 con DTOs, sin ciclos
+        return ResponseEntity.ok(dtoList); 
     }
 
+    
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<EstudioResponseDto>> findById(@PathVariable("id") Long id) {
-        Estudio estudio = service.findById(id);
-        EstudioResponseDto dto = new EstudioResponseDto(estudio);
-
-        ApiResponseSuccessDto<EstudioResponseDto> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Estudio (DTO)",
-                dto
-        );
-        return ResponseEntity.ok(resp);
+    public ResponseEntity<EstudioResponseDto> findById(@PathVariable("id") Long id) {
+        if (!service.existsById(id)) {
+            return ResponseEntity.noContent().build();
+        }
+        Estudio entidad = service.findById(id);
+        EstudioResponseDto dto = new EstudioResponseDto(entidad); 
+        return ResponseEntity.ok(dto);
     }
 
-    @GetMapping("/completo")
-    public ResponseEntity<ApiResponseSuccessDto<List<EstudioResponseDto>>> findAllDTO() {
-        List<EstudioResponseDto> lista = service.findAll().stream()
-                .map(EstudioResponseDto::new)
-                .collect(Collectors.toList());
-
-        ApiResponseSuccessDto<List<EstudioResponseDto>> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Listado de estudios (DTO) obtenido correctamente",
-                lista
-        );
-        return ResponseEntity.ok(resp);
-    }
-
+    
     @PostMapping
-    public ResponseEntity<ApiResponseSuccessDto<Estudio>> create(
-            @Valid @RequestBody EstudioRequestDto dto) throws Exception {
-        Estudio creado = service.create(service.fromDto(dto));
-        ApiResponseSuccessDto<Estudio> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Estudio creado correctamente",
-                creado
-        );
-        return ResponseEntity.status(201).body(resp);
+    public ResponseEntity<EstudioResponseDto> create(@Valid @RequestBody EstudioRequestDto dto) {
+        Estudio entidad = service.create(service.fromDto(dto));
+        return ResponseEntity.ok(new EstudioResponseDto(entidad));
     }
 
+    
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<Estudio>> update(
-            @PathVariable("id") Long id,
-            @Valid @RequestBody EstudioRequestDto dto) throws Exception {
+    public ResponseEntity<EstudioResponseDto> update(@PathVariable("id") Long id,
+                                                     @Valid @RequestBody EstudioRequestDto dto) {
+        if (!service.existsById(id)) {
+            return ResponseEntity.noContent().build();
+        }
         Estudio actualizado = service.update(id, service.fromDto(dto));
-        ApiResponseSuccessDto<Estudio> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Estudio actualizado correctamente",
-                actualizado
-        );
-        return ResponseEntity.ok(resp);
+        return ResponseEntity.ok(new EstudioResponseDto(actualizado)); 
     }
 
+    
     @DeleteMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<Void>> delete(@PathVariable("id") Long id) {
+    public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
+        if (!service.existsById(id)) {
+            return ResponseEntity.noContent().build(); // 204 si no existe
+        }
         service.deleteById(id);
-        ApiResponseSuccessDto<Void> resp = new ApiResponseSuccessDto<>(
-                true,
-                "Estudio " + id + " eliminado correctamente.",
-                null
-        );
-        return ResponseEntity.ok(resp);
+        return ResponseEntity.ok().build(); // 200
     }
 }

--- a/src/main/java/com/imb2025/smedico/controller/EstudioController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EstudioController.java
@@ -4,17 +4,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import com.imb2025.smedico.dto.ApiResponseErrorDto;
 import com.imb2025.smedico.dto.ApiResponseSuccessDto;
 import com.imb2025.smedico.dto.EstudioRequestDto;
 import com.imb2025.smedico.dto.EstudioResponseDto;
-import com.imb2025.smedico.dto.FieldErrorDto;
 import com.imb2025.smedico.entity.Estudio;
-import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.service.IEstudioService;
 
 import jakarta.validation.Valid;
@@ -26,59 +22,37 @@ public class EstudioController {
     @Autowired
     private IEstudioService service;
 
-   /* @GetMapping
-    public ResponseEntity<List<Estudio>> findAll() {
+    @GetMapping
+    public ResponseEntity<?> findAll() {
         List<Estudio> lista = service.findAll();
         if (lista.isEmpty()) {
-            return ResponseEntity.noContent().build();
+            return ResponseEntity.noContent().build(); // 204 sin body
         }
-        return ResponseEntity.ok(lista);
-    }*/
-    
-    @GetMapping
-    public ResponseEntity<ApiResponseSuccessDto<List<Estudio>>> findAll() {
-        List<Estudio> lista = service.findAll();
+        List<EstudioResponseDto> dtoList = lista.stream()
+                .map(EstudioResponseDto::new)
+                .collect(Collectors.toList());
 
-        ApiResponseSuccessDto<List<Estudio>> resp = new ApiResponseSuccessDto<>(
+        ApiResponseSuccessDto<List<EstudioResponseDto>> resp = new ApiResponseSuccessDto<>(
                 true,
-                lista.isEmpty() ? "No se encontraron estudios" : "Listado de estudios obtenido correctamente",
-                lista
+                "Listado de estudios (DTO)",
+                dtoList
         );
-
-        return lista.isEmpty() ? ResponseEntity.noContent().build() : ResponseEntity.ok(resp);
+        return ResponseEntity.ok(resp); // 200 con DTOs, sin ciclos
     }
-   
 
-    /*@GetMapping("/{id}")
-    public ResponseEntity<Estudio> findById(@PathVariable("id") Long id) {
-        Estudio estudio = service.findById(id);
-        if (estudio == null) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(estudio);
-    }*/
-    
     @GetMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<Estudio>> findById(@PathVariable("id") Long id) {
+    public ResponseEntity<ApiResponseSuccessDto<EstudioResponseDto>> findById(@PathVariable("id") Long id) {
         Estudio estudio = service.findById(id);
+        EstudioResponseDto dto = new EstudioResponseDto(estudio);
 
-        ApiResponseSuccessDto<Estudio> resp = new ApiResponseSuccessDto<>(
+        ApiResponseSuccessDto<EstudioResponseDto> resp = new ApiResponseSuccessDto<>(
                 true,
-                "Estudio encontrado correctamente",
-                estudio
+                "Estudio (DTO)",
+                dto
         );
-
         return ResponseEntity.ok(resp);
     }
 
-    /*@GetMapping("/completo")
-    public ResponseEntity<List<EstudioResponseDTO>> findAllDTO() {
-        List<EstudioResponseDTO> lista = service.findAll().stream()
-                .map(EstudioResponseDTO::new)
-                .collect(Collectors.toList());
-        return ResponseEntity.ok(lista);
-    }*/
-    
     @GetMapping("/completo")
     public ResponseEntity<ApiResponseSuccessDto<List<EstudioResponseDto>>> findAllDTO() {
         List<EstudioResponseDto> lista = service.findAll().stream()
@@ -90,69 +64,42 @@ public class EstudioController {
                 "Listado de estudios (DTO) obtenido correctamente",
                 lista
         );
-
         return ResponseEntity.ok(resp);
     }
 
-    /*@PostMapping
-    public ResponseEntity<Estudio> create(@RequestBody EstudioRequestDto dto) throws Exception {
-        Estudio estudio = service.fromDto(dto);
-        Estudio creado = service.create(estudio);
-        return ResponseEntity.ok(creado);
-    }*/
-    
     @PostMapping
-    public ResponseEntity<ApiResponseSuccessDto<Estudio>> create(@Valid @RequestBody EstudioRequestDto dto) throws Exception {
-        Estudio estudio = service.fromDto(dto);
-        Estudio creado = service.create(estudio);
-
+    public ResponseEntity<ApiResponseSuccessDto<Estudio>> create(
+            @Valid @RequestBody EstudioRequestDto dto) throws Exception {
+        Estudio creado = service.create(service.fromDto(dto));
         ApiResponseSuccessDto<Estudio> resp = new ApiResponseSuccessDto<>(
                 true,
                 "Estudio creado correctamente",
                 creado
         );
-
         return ResponseEntity.status(201).body(resp);
     }
 
-    /*@PutMapping("/{id}")
-    public ResponseEntity<Estudio> update(@PathVariable("id") Long id, @RequestBody EstudioRequestDto dto) throws Exception {
-        Estudio estudio = service.fromDto(dto);
-        Estudio actualizado = service.update(id, estudio);
-        return ResponseEntity.ok(actualizado);
-    }*/
-    
     @PutMapping("/{id}")
-    public ResponseEntity<ApiResponseSuccessDto<Estudio>> update(@PathVariable("id") Long id, @Valid @RequestBody EstudioRequestDto dto) throws Exception {
-        Estudio estudio = service.fromDto(dto);
-        Estudio actualizado = service.update(id, estudio);
-
+    public ResponseEntity<ApiResponseSuccessDto<Estudio>> update(
+            @PathVariable("id") Long id,
+            @Valid @RequestBody EstudioRequestDto dto) throws Exception {
+        Estudio actualizado = service.update(id, service.fromDto(dto));
         ApiResponseSuccessDto<Estudio> resp = new ApiResponseSuccessDto<>(
                 true,
                 "Estudio actualizado correctamente",
                 actualizado
         );
-
         return ResponseEntity.ok(resp);
     }
 
-    /*@DeleteMapping("/{id}")
-    public ResponseEntity<String> delete(@PathVariable("id") Long id) {
-        service.deleteById(id);
-        return ResponseEntity.ok("Estudio " + id + " eliminado correctamente.");
-    }*/
-    
     @DeleteMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<Void>> delete(@PathVariable("id") Long id) {
         service.deleteById(id);
-
         ApiResponseSuccessDto<Void> resp = new ApiResponseSuccessDto<>(
                 true,
                 "Estudio " + id + " eliminado correctamente.",
                 null
         );
-
         return ResponseEntity.ok(resp);
     }
-
 }

--- a/src/main/java/com/imb2025/smedico/dto/EstudioRequestDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/EstudioRequestDto.java
@@ -6,6 +6,10 @@ import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public class EstudioRequestDto {
+	
+	@NotNull(message = "El ID del paciente es obligatorio.")
+    @Positive(message = "El ID del paciente debe ser un número positivo.")
+    private Long pacientId;
 
 	@NotBlank(message = "El nombre del estudio no puede estar vacío.")
     @Size(min = 3, max = 150, message = "El nombre debe tener entre 3 y 150 caracteres.")
@@ -15,24 +19,9 @@ public class EstudioRequestDto {
     @Size(min = 10, max = 500, message = "La descripción debe tener entre 10 y 500 caracteres.")
     private String descripcion;
 
-    @NotNull(message = "El ID del paciente es obligatorio.")
-    @Positive(message = "El ID del paciente debe ser un número positivo.")
-    private Long pacientId;
-
-    @NotNull(message = "El ID del médico es obligatorio.")
-    @Positive(message = "El ID del médico debe ser un número positivo.")
-    private Long medicoId;
-
     @NotNull(message = "El ID de la especialidad es obligatorio.")
     @Positive(message = "El ID de la especialidad debe ser un número positivo.")
     private Long especialidadId;
-
-    @NotNull(message = "El ID de la obra social es obligatorio.")
-    @Positive(message = "El ID de la obra social debe ser un número positivo.")
-    private Long obraSocialId;
-
-    @Positive(message = "El ID de la orden de estudio debe ser un número positivo.")
-    private Long oredenEstudioId;
 
     @Positive(message = "El ID del resultado de estudio debe ser un número positivo.")
     private Long resultadoEstudioId;
@@ -40,22 +29,23 @@ public class EstudioRequestDto {
     public EstudioRequestDto() {}
 
     public EstudioRequestDto(
+    		Long pacientId,
             String nombre,
             String descripcion,
-            Long pacientId,
-            Long medicoId,
             Long especialidadId,
-            Long obraSocialId,
-            Long oredenEstudioId,
             Long resultadoEstudioId) {
+    	this.pacientId = pacientId;
         this.nombre = nombre;
         this.descripcion = descripcion;
-        this.pacientId = pacientId;
-        this.medicoId = medicoId;
         this.especialidadId = especialidadId;
-        this.obraSocialId = obraSocialId;
-        this.oredenEstudioId = oredenEstudioId;
         this.resultadoEstudioId = resultadoEstudioId;
+    }
+    public Long getPacientId() {
+        return pacientId;
+    }
+
+    public void setPacientId(Long pacientId) {
+        this.pacientId = pacientId;
     }
 
     public String getNombre() {
@@ -74,44 +64,12 @@ public class EstudioRequestDto {
         this.descripcion = descripcion;
     }
 
-    public Long getPacientId() {
-        return pacientId;
-    }
-
-    public void setPacientId(Long pacientId) {
-        this.pacientId = pacientId;
-    }
-
-    public Long getMedicoId() {
-        return medicoId;
-    }
-
-    public void setMedicoId(Long medicoId) {
-        this.medicoId = medicoId;
-    }
-
     public Long getEspecialidadId() {
         return especialidadId;
     }
 
     public void setEspecialidadId(Long especialidadId) {
         this.especialidadId = especialidadId;
-    }
-
-    public Long getObraSocialId() {
-        return obraSocialId;
-    }
-
-    public void setObraSocialId(Long obraSocialId) {
-        this.obraSocialId = obraSocialId;
-    }
-
-    public Long getOredenEstudioId() {
-        return oredenEstudioId;
-    }
-
-    public void setOredenEstudioId(Long oredenEstudioId) {
-        this.oredenEstudioId = oredenEstudioId;
     }
 
     public Long getResultadoEstudioId() {

--- a/src/main/java/com/imb2025/smedico/dto/EstudioRequestDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/EstudioRequestDto.java
@@ -7,10 +7,6 @@ import jakarta.validation.constraints.Size;
 
 public class EstudioRequestDto {
 	
-	@NotNull(message = "El ID del paciente es obligatorio.")
-    @Positive(message = "El ID del paciente debe ser un número positivo.")
-    private Long pacientId;
-
 	@NotBlank(message = "El nombre del estudio no puede estar vacío.")
     @Size(min = 3, max = 150, message = "El nombre debe tener entre 3 y 150 caracteres.")
     private String nombre;
@@ -29,23 +25,14 @@ public class EstudioRequestDto {
     public EstudioRequestDto() {}
 
     public EstudioRequestDto(
-    		Long pacientId,
             String nombre,
             String descripcion,
             Long especialidadId,
             Long resultadoEstudioId) {
-    	this.pacientId = pacientId;
         this.nombre = nombre;
         this.descripcion = descripcion;
         this.especialidadId = especialidadId;
         this.resultadoEstudioId = resultadoEstudioId;
-    }
-    public Long getPacientId() {
-        return pacientId;
-    }
-
-    public void setPacientId(Long pacientId) {
-        this.pacientId = pacientId;
     }
 
     public String getNombre() {

--- a/src/main/java/com/imb2025/smedico/dto/EstudioResponseDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/EstudioResponseDto.java
@@ -1,102 +1,39 @@
 package com.imb2025.smedico.dto;
 
-import java.time.LocalDate;
-
 public class EstudioResponseDto {
 
-	private Long id;
-	private String nombre;
-	private String descripcion;
-	private String pacienteNombre;
-    private String medicoNombre;
+    private Long id;
+    private String nombre;
+    private String descripcion;
     private String especialidadNombre;
-    private String obraSocialNombre;
-    private LocalDate ordenFecha;
     private String resultadoDescripcion;
-    
+
     public EstudioResponseDto(com.imb2025.smedico.entity.Estudio estudio) {
         this.id = estudio.getId();
         this.nombre = estudio.getNombre();
         this.descripcion = estudio.getDescripcion();
-        this.pacienteNombre = estudio.getPaciente() != null ? estudio.getPaciente().getNombre() : null;
-        this.medicoNombre = estudio.getMedico() != null ? estudio.getMedico().getNombre() : null;
-        this.especialidadNombre = estudio.getEspecialidad() != null ? estudio.getEspecialidad().getNombre() : null;
-        this.obraSocialNombre = estudio.getObraSocial() != null ? estudio.getObraSocial().getNombre() : null;
-        this.ordenFecha = estudio.getOredenEstudio() != null ? estudio.getOredenEstudio().getFecha() : null;
-        this.resultadoDescripcion = estudio.getResultadoEstudio() != null ? estudio.getResultadoEstudio().getObservaciones() : null;
+        this.especialidadNombre = (estudio.getEspecialidad() != null)
+                ? estudio.getEspecialidad().getNombre()
+                : null;
+        this.resultadoDescripcion = (estudio.getResultadoEstudio() != null)
+                ? estudio.getResultadoEstudio().getObservaciones()
+                : null;
     }
 
-	public Long getId() {
-		return id;
-	}
+    public EstudioResponseDto() {}
 
-	public void setId(Long id) {
-		this.id = id;
-	}
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
 
-	public String getNombre() {
-		return nombre;
-	}
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
 
-	public void setNombre(String nombre) {
-		this.nombre = nombre;
-	}
+    public String getDescripcion() { return descripcion; }
+    public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
 
-	public String getDescripcion() {
-		return descripcion;
-	}
+    public String getEspecialidadNombre() { return especialidadNombre; }
+    public void setEspecialidadNombre(String especialidadNombre) { this.especialidadNombre = especialidadNombre; }
 
-	public void setDescripcion(String descripcion) {
-		this.descripcion = descripcion;
-	}
-
-	public String getPacienteNombre() {
-		return pacienteNombre;
-	}
-
-	public void setPacienteNombre(String pacienteNombre) {
-		this.pacienteNombre = pacienteNombre;
-	}
-
-	public String getMedicoNombre() {
-		return medicoNombre;
-	}
-
-	public void setMedicoNombre(String medicoNombre) {
-		this.medicoNombre = medicoNombre;
-	}
-
-	public String getEspecialidadNombre() {
-		return especialidadNombre;
-	}
-
-	public void setEspecialidadNombre(String especialidadNombre) {
-		this.especialidadNombre = especialidadNombre;
-	}
-
-	public String getObraSocialNombre() {
-		return obraSocialNombre;
-	}
-
-	public void setObraSocialNombre(String obraSocialNombre) {
-		this.obraSocialNombre = obraSocialNombre;
-	}
-
-	public LocalDate getOrdenFecha() {
-		return ordenFecha;
-	}
-
-	public void setOrdenFecha(LocalDate ordenFecha) {
-		this.ordenFecha = ordenFecha;
-	}
-
-	public String getResultadoDescripcion() {
-		return resultadoDescripcion;
-	}
-
-	public void setResultadoDescripcion(String resultadoDescripcion) {
-		this.resultadoDescripcion = resultadoDescripcion;
-	}
-
-    
+    public String getResultadoDescripcion() { return resultadoDescripcion; }
+    public void setResultadoDescripcion(String resultadoDescripcion) { this.resultadoDescripcion = resultadoDescripcion; }
 }

--- a/src/main/java/com/imb2025/smedico/entity/Estudio.java
+++ b/src/main/java/com/imb2025/smedico/entity/Estudio.java
@@ -1,5 +1,6 @@
 package com.imb2025.smedico.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,31 +17,39 @@ public class Estudio {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String nombre;
     private String descripcion;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "paciente_id")
+    @JsonIgnoreProperties("estudios")
     private Paciente paciente;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "medico_id")
+    @JsonIgnoreProperties("estudios")
     private Medico medico;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "especialidad_id")
+    @JsonIgnoreProperties("estudios")
     private Especialidad especialidad;
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "obra_social_id")
+    @JsonIgnoreProperties("estudios")
     private ObraSocial obraSocial;
 
+    // Conservamos OneToOne como en tu modelo
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "orden_estudio_id")
+    @JsonIgnoreProperties("estudios")
     private OrdenEstudio oredenEstudio;
 
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "resultado_estudio_id")
+    @JsonIgnoreProperties("estudios")
     private ResultadoEstudio resultadoEstudio;
 
     public Estudio() {}
@@ -59,60 +68,30 @@ public class Estudio {
         this.resultadoEstudio = resultadoEstudio;
     }
 
-    public Long getId() {
-        return id;
-    }
-    public void setId(Long id) {
-        this.id = id;
-    }
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
 
-    public String getNombre() {
-        return nombre;
-    }
-    public void setNombre(String nombre) {
-        this.nombre = nombre;
-    }
-    public String getDescripcion() {
-        return descripcion;
-    }
-    public void setDescripcion(String descripcion) {
-        this.descripcion = descripcion;
-    }
+    public String getNombre() { return nombre; }
+    public void setNombre(String nombre) { this.nombre = nombre; }
 
-    public Paciente getPaciente() {
-        return paciente;
-    }
-    public void setPaciente(Paciente paciente) {
-        this.paciente = paciente;
-    }
-    public Medico getMedico() {
-        return medico;
-    }
-    public void setMedico(Medico medico) {
-        this.medico = medico;
-    }
-    public Especialidad getEspecialidad() {
-        return especialidad;
-    }
-    public void setEspecialidad(Especialidad especialidad) {
-        this.especialidad = especialidad;
-    }
-    public ObraSocial getObraSocial() {
-        return obraSocial;
-    }
-    public void setObraSocial(ObraSocial obraSocial) {
-        this.obraSocial = obraSocial;
-    }
-    public OrdenEstudio getOredenEstudio() {
-        return oredenEstudio;
-    }
-    public void setOredenEstudio(OrdenEstudio oredenEstudio) {
-        this.oredenEstudio = oredenEstudio;
-    }
-    public ResultadoEstudio getResultadoEstudio() {
-        return resultadoEstudio;
-    }
-    public void setResultadoEstudio(ResultadoEstudio resultadoEstudio) {
-        this.resultadoEstudio = resultadoEstudio;
-    }
+    public String getDescripcion() { return descripcion; }
+    public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
+
+    public Paciente getPaciente() { return paciente; }
+    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
+
+    public Medico getMedico() { return medico; }
+    public void setMedico(Medico medico) { this.medico = medico; }
+
+    public Especialidad getEspecialidad() { return especialidad; }
+    public void setEspecialidad(Especialidad especialidad) { this.especialidad = especialidad; }
+
+    public ObraSocial getObraSocial() { return obraSocial; }
+    public void setObraSocial(ObraSocial obraSocial) { this.obraSocial = obraSocial; }
+
+    public OrdenEstudio getOredenEstudio() { return oredenEstudio; }
+    public void setOredenEstudio(OrdenEstudio oredenEstudio) { this.oredenEstudio = oredenEstudio; }
+
+    public ResultadoEstudio getResultadoEstudio() { return resultadoEstudio; }
+    public void setResultadoEstudio(ResultadoEstudio resultadoEstudio) { this.resultadoEstudio = resultadoEstudio; }
 }

--- a/src/main/java/com/imb2025/smedico/entity/Estudio.java
+++ b/src/main/java/com/imb2025/smedico/entity/Estudio.java
@@ -1,35 +1,29 @@
 package com.imb2025.smedico.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 
-@Table(name = "estudio")
 @Entity
+@Table(name = "estudio")
 public class Estudio {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 150, nullable = false)
     private String nombre;
+
+    @Column(length = 500, nullable = false)
     private String descripcion;
 
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "especialidad_id")
-    @JsonIgnoreProperties("estudios")
+    // Muchas estudios pertenecen a una especialidad
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "especialidad_id", nullable = false)
     private Especialidad especialidad;
 
-    @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "resultado_estudio_id")
-    @JsonIgnoreProperties("estudios")
+    // Relación 1–1 unidireccional: la FK está en Estudio
+    @OneToOne(fetch = FetchType.LAZY, optional = true)
+    @JoinColumn(name = "resultado_estudio_id", unique = true)
     private ResultadoEstudio resultadoEstudio;
 
     public Estudio() {}

--- a/src/main/java/com/imb2025/smedico/entity/Estudio.java
+++ b/src/main/java/com/imb2025/smedico/entity/Estudio.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Table;
 @Table(name = "estudio")
 @Entity
 public class Estudio {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -22,30 +23,9 @@ public class Estudio {
     private String descripcion;
 
     @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "paciente_id")
-    @JsonIgnoreProperties("estudios")
-    private Paciente paciente;
-
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "medico_id")
-    @JsonIgnoreProperties("estudios")
-    private Medico medico;
-
-    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "especialidad_id")
     @JsonIgnoreProperties("estudios")
     private Especialidad especialidad;
-
-    @ManyToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "obra_social_id")
-    @JsonIgnoreProperties("estudios")
-    private ObraSocial obraSocial;
-
-    // Conservamos OneToOne como en tu modelo
-    @OneToOne(fetch = FetchType.EAGER)
-    @JoinColumn(name = "orden_estudio_id")
-    @JsonIgnoreProperties("estudios")
-    private OrdenEstudio oredenEstudio;
 
     @OneToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "resultado_estudio_id")
@@ -54,17 +34,12 @@ public class Estudio {
 
     public Estudio() {}
 
-    public Estudio(Long id, String nombre, String descripcion, Paciente paciente, Medico medico,
-                   Especialidad especialidad, ObraSocial obraSocial, OrdenEstudio oredenEstudio,
-                   ResultadoEstudio resultadoEstudio) {
+    public Estudio(Long id, String nombre, String descripcion,
+                   Especialidad especialidad, ResultadoEstudio resultadoEstudio) {
         this.id = id;
         this.nombre = nombre;
         this.descripcion = descripcion;
-        this.paciente = paciente;
-        this.medico = medico;
         this.especialidad = especialidad;
-        this.obraSocial = obraSocial;
-        this.oredenEstudio = oredenEstudio;
         this.resultadoEstudio = resultadoEstudio;
     }
 
@@ -77,20 +52,8 @@ public class Estudio {
     public String getDescripcion() { return descripcion; }
     public void setDescripcion(String descripcion) { this.descripcion = descripcion; }
 
-    public Paciente getPaciente() { return paciente; }
-    public void setPaciente(Paciente paciente) { this.paciente = paciente; }
-
-    public Medico getMedico() { return medico; }
-    public void setMedico(Medico medico) { this.medico = medico; }
-
     public Especialidad getEspecialidad() { return especialidad; }
     public void setEspecialidad(Especialidad especialidad) { this.especialidad = especialidad; }
-
-    public ObraSocial getObraSocial() { return obraSocial; }
-    public void setObraSocial(ObraSocial obraSocial) { this.obraSocial = obraSocial; }
-
-    public OrdenEstudio getOredenEstudio() { return oredenEstudio; }
-    public void setOredenEstudio(OrdenEstudio oredenEstudio) { this.oredenEstudio = oredenEstudio; }
 
     public ResultadoEstudio getResultadoEstudio() { return resultadoEstudio; }
     public void setResultadoEstudio(ResultadoEstudio resultadoEstudio) { this.resultadoEstudio = resultadoEstudio; }

--- a/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
@@ -1,12 +1,8 @@
 package com.imb2025.smedico.repository;
 
-import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import com.imb2025.smedico.entity.Estudio;
 
 public interface EstudioRepository extends JpaRepository<Estudio, Long> {
 
-    @EntityGraph(attributePaths = { "especialidad", "resultadoEstudio" })
-    List<Estudio> findAll();
 }

--- a/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/EstudioRepository.java
@@ -1,17 +1,12 @@
 package com.imb2025.smedico.repository;
 
 import java.util.List;
-
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.imb2025.smedico.entity.Estudio;
 
 public interface EstudioRepository extends JpaRepository<Estudio, Long> {
 
-    @EntityGraph(attributePaths = {
-            "paciente", "medico", "especialidad", "obraSocial", "oredenEstudio", "resultadoEstudio"
-    })
+    @EntityGraph(attributePaths = { "especialidad", "resultadoEstudio" })
     List<Estudio> findAll();
-
 }

--- a/src/main/java/com/imb2025/smedico/service/IEstudioService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEstudioService.java
@@ -6,10 +6,10 @@ import java.util.List;
 
 public interface IEstudioService {
     public List<Estudio> findAll();
-    public Estudio create(Estudio estudio) throws Exception;
-    public Estudio update(Long id, Estudio estudio) throws Exception;
+    public Estudio create(Estudio estudio);
+    public Estudio update(Long id, Estudio estudio);
     public Estudio findById(Long id);
     public boolean existsById(Long id);
     public void deleteById(Long id);
-    public Estudio fromDto(EstudioRequestDto estudioRequestDto) throws Exception;
+    public Estudio fromDto(EstudioRequestDto estudioRequestDto);
 }

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
@@ -6,40 +6,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.imb2025.smedico.dto.EstudioRequestDto;
-import com.imb2025.smedico.entity.Especialidad;
-import com.imb2025.smedico.entity.Estudio;
-import com.imb2025.smedico.entity.Medico;
-import com.imb2025.smedico.entity.ObraSocial;
-import com.imb2025.smedico.entity.OrdenEstudio;
-import com.imb2025.smedico.entity.Paciente;
-import com.imb2025.smedico.entity.ResultadoEstudio;
+import com.imb2025.smedico.entity.*;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.EspecialidadRepository;
-import com.imb2025.smedico.repository.EstudioRepository;
-import com.imb2025.smedico.repository.MedicoRepository;
-import com.imb2025.smedico.repository.ObraSocialRepository;
-import com.imb2025.smedico.repository.OrdenEstudioRepository;
-import com.imb2025.smedico.repository.PacienteRepository;
-import com.imb2025.smedico.repository.ResultadoEstudioRepository;
+import com.imb2025.smedico.repository.*;
 import com.imb2025.smedico.service.IEstudioService;
 
 @Service
 public class EstudioServiceImpl implements IEstudioService {
 
-    @Autowired
-    private EstudioRepository repo;
-    @Autowired
-    private PacienteRepository repoPaciente;
-    @Autowired
-    private MedicoRepository repoMedico;
-    @Autowired
-    private EspecialidadRepository repoEspecialidad;
-    @Autowired
-    private ObraSocialRepository repoObraSocial;
-    @Autowired
-    private OrdenEstudioRepository repoOredenEstudio;
-    @Autowired
-    private ResultadoEstudioRepository repoResultadoEstudio;
+    @Autowired private EstudioRepository repo;
+    @Autowired private PacienteRepository repoPaciente;
+    @Autowired private MedicoRepository repoMedico;
+    @Autowired private EspecialidadRepository repoEspecialidad;
+    @Autowired private ObraSocialRepository repoObraSocial;
+    @Autowired private OrdenEstudioRepository repoOredenEstudio;
+    @Autowired private ResultadoEstudioRepository repoResultadoEstudio;
 
     @Override
     public List<Estudio> findAll() {
@@ -49,8 +30,7 @@ public class EstudioServiceImpl implements IEstudioService {
     @Override
     public Estudio findById(Long id) {
         return repo.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "Estudio no encontrado con id " + id));
+            .orElseThrow(() -> new ResourceNotFoundException("Estudio no encontrado con id " + id));
     }
 
     @Override
@@ -66,7 +46,7 @@ public class EstudioServiceImpl implements IEstudioService {
     @Override
     public Estudio update(Long id, Estudio estudio) throws Exception {
         if (!repo.existsById(id)) {
-            throw new Exception("No existe el estudio con ID: " + id);
+            throw new ResourceNotFoundException("No existe el estudio con ID: " + id);
         }
         estudio.setId(id);
         return repo.save(estudio);
@@ -75,34 +55,43 @@ public class EstudioServiceImpl implements IEstudioService {
     @Override
     public void deleteById(Long id) {
         if (!repo.existsById(id)) {
-            throw new RuntimeException("Estudio con ID " + id + " no existe.");
+            throw new ResourceNotFoundException("Estudio con ID " + id + " no existe.");
         }
         repo.deleteById(id);
     }
 
     @Override
     public Estudio fromDto(EstudioRequestDto dto) throws Exception {
-    	Especialidad especialidad = repoEspecialidad.findById(dto.getEspecialidadId())
-    			.orElseThrow(() -> new Exception("Especialidad no encontrada"));
-    	Paciente paciente = repoPaciente.findById(dto.getPacientId())
-    			.orElseThrow(() -> new Exception("Paciente no encontrado"));
+        Especialidad especialidad = repoEspecialidad.findById(dto.getEspecialidadId())
+            .orElseThrow(() -> new ResourceNotFoundException("Especialidad no encontrada"));
+        Paciente paciente = repoPaciente.findById(dto.getPacientId())
+            .orElseThrow(() -> new ResourceNotFoundException("Paciente no encontrado"));
         Medico medico = repoMedico.findById(dto.getMedicoId())
-        		.orElseThrow(() -> new Exception("Médico no encontrado"));
+            .orElseThrow(() -> new ResourceNotFoundException("Médico no encontrado"));
         ObraSocial obraSocial = repoObraSocial.findById(dto.getObraSocialId())
-        		.orElseThrow(() -> new Exception("Obra social no encontrada"));
-        OrdenEstudio ordenEstudio = repoOredenEstudio.findById(dto.getOredenEstudioId())
-        		.orElseThrow(() -> new Exception("Orden de estudio no encontrada"));            
-    	ResultadoEstudio resultadoEstudio = repoResultadoEstudio.findById(dto.getResultadoEstudioId())
-    			.orElseThrow(() -> new Exception("Resultado de estudio no encontrado"));
-        		
-    	Estudio estudio = new Estudio();
-    	estudio.setDescripcion(dto.getDescripcion());
-    	estudio.setEspecialidad(especialidad);
-    	estudio.setMedico(medico);
-    	estudio.setObraSocial(obraSocial);
-    	estudio.setOredenEstudio(ordenEstudio);
-    	estudio.setPaciente(paciente);
-    	estudio.setResultadoEstudio(resultadoEstudio);
-    	return estudio;
+            .orElseThrow(() -> new ResourceNotFoundException("Obra social no encontrada"));
+
+        OrdenEstudio ordenEstudio = null;
+        if (dto.getOredenEstudioId() != null) {
+            ordenEstudio = repoOredenEstudio.findById(dto.getOredenEstudioId())
+                .orElseThrow(() -> new ResourceNotFoundException("Orden de estudio no encontrada"));
+        }
+
+        ResultadoEstudio resultadoEstudio = null;
+        if (dto.getResultadoEstudioId() != null) {
+            resultadoEstudio = repoResultadoEstudio.findById(dto.getResultadoEstudioId())
+                .orElseThrow(() -> new ResourceNotFoundException("Resultado de estudio no encontrado"));
+        }
+
+        Estudio estudio = new Estudio();
+        estudio.setNombre(dto.getNombre());            // (nuevo) mapeo de nombre
+        estudio.setDescripcion(dto.getDescripcion());
+        estudio.setEspecialidad(especialidad);
+        estudio.setMedico(medico);
+        estudio.setObraSocial(obraSocial);
+        estudio.setOredenEstudio(ordenEstudio);
+        estudio.setPaciente(paciente);
+        estudio.setResultadoEstudio(resultadoEstudio);
+        return estudio;
     }
 }

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
@@ -6,92 +6,89 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.imb2025.smedico.dto.EstudioRequestDto;
-import com.imb2025.smedico.entity.*;
+import com.imb2025.smedico.entity.Especialidad;
+import com.imb2025.smedico.entity.Estudio;
+import com.imb2025.smedico.entity.ResultadoEstudio;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.*;
+import com.imb2025.smedico.repository.EspecialidadRepository;
+import com.imb2025.smedico.repository.EstudioRepository;
+import com.imb2025.smedico.repository.ResultadoEstudioRepository;
 import com.imb2025.smedico.service.IEstudioService;
 
 @Service
 public class EstudioServiceImpl implements IEstudioService {
 
-    @Autowired private EstudioRepository repo;
-    @Autowired private PacienteRepository repoPaciente;
-    @Autowired private MedicoRepository repoMedico;
-    @Autowired private EspecialidadRepository repoEspecialidad;
-    @Autowired private ObraSocialRepository repoObraSocial;
-    @Autowired private OrdenEstudioRepository repoOredenEstudio;
-    @Autowired private ResultadoEstudioRepository repoResultadoEstudio;
+    @Autowired
+    private EstudioRepository repoEstudio;
+
+    @Autowired
+    private EspecialidadRepository repoEspecialidad;
+
+    @Autowired
+    private ResultadoEstudioRepository repoResultadoEstudio;
 
     @Override
     public List<Estudio> findAll() {
-        return repo.findAll();
+        return repoEstudio.findAll();
     }
 
     @Override
     public Estudio findById(Long id) {
-        return repo.findById(id)
-            .orElseThrow(() -> new ResourceNotFoundException("Estudio no encontrado con id " + id));
+        return repoEstudio.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Estudio no encontrado con id " + id));
     }
 
     @Override
     public boolean existsById(Long id) {
-        return repo.existsById(id);
-    }
-
-    @Override
-    public Estudio create(Estudio estudio) throws Exception {
-        return repo.save(estudio);
-    }
-
-    @Override
-    public Estudio update(Long id, Estudio estudio) throws Exception {
-        if (!repo.existsById(id)) {
-            throw new ResourceNotFoundException("No existe el estudio con ID: " + id);
-        }
-        estudio.setId(id);
-        return repo.save(estudio);
+        return repoEstudio.existsById(id);
     }
 
     @Override
     public void deleteById(Long id) {
-        if (!repo.existsById(id)) {
-            throw new ResourceNotFoundException("Estudio con ID " + id + " no existe.");
+        if (!existsById(id)) {
+            throw new ResourceNotFoundException("Estudio no encontrado con id " + id);
         }
-        repo.deleteById(id);
+        repoEstudio.deleteById(id);
+    }
+
+    @Override
+    public Estudio create(Estudio estudio) throws Exception {
+        // Verificación mínima, coherente con tus lineamientos
+        if (estudio.getEspecialidad() == null) throw new Exception("Especialidad es obligatoria");
+        // nombre puede ser obligatorio según tu DTO; si querés, valida acá
+        return repoEstudio.save(estudio);
+    }
+
+    @Override
+    public Estudio update(Long id, Estudio estudio) throws Exception {
+        Estudio existente = repoEstudio.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Estudio no encontrado con id " + id));
+        existente.setNombre(estudio.getNombre());
+        existente.setDescripcion(estudio.getDescripcion());
+        existente.setEspecialidad(estudio.getEspecialidad());
+        existente.setResultadoEstudio(estudio.getResultadoEstudio());
+
+        return repoEstudio.save(existente);
     }
 
     @Override
     public Estudio fromDto(EstudioRequestDto dto) throws Exception {
         Especialidad especialidad = repoEspecialidad.findById(dto.getEspecialidadId())
-            .orElseThrow(() -> new ResourceNotFoundException("Especialidad no encontrada"));
-        Paciente paciente = repoPaciente.findById(dto.getPacientId())
-            .orElseThrow(() -> new ResourceNotFoundException("Paciente no encontrado"));
-        Medico medico = repoMedico.findById(dto.getMedicoId())
-            .orElseThrow(() -> new ResourceNotFoundException("Médico no encontrado"));
-        ObraSocial obraSocial = repoObraSocial.findById(dto.getObraSocialId())
-            .orElseThrow(() -> new ResourceNotFoundException("Obra social no encontrada"));
+                .orElseThrow(() -> new Exception("Especialidad no encontrada"));
 
-        OrdenEstudio ordenEstudio = null;
-        if (dto.getOredenEstudioId() != null) {
-            ordenEstudio = repoOredenEstudio.findById(dto.getOredenEstudioId())
-                .orElseThrow(() -> new ResourceNotFoundException("Orden de estudio no encontrada"));
-        }
-
+ 
         ResultadoEstudio resultadoEstudio = null;
         if (dto.getResultadoEstudioId() != null) {
             resultadoEstudio = repoResultadoEstudio.findById(dto.getResultadoEstudioId())
-                .orElseThrow(() -> new ResourceNotFoundException("Resultado de estudio no encontrado"));
+                    .orElseThrow(() -> new Exception("Resultado de estudio no encontrado"));
         }
 
         Estudio estudio = new Estudio();
-        estudio.setNombre(dto.getNombre());            // (nuevo) mapeo de nombre
+        estudio.setNombre(dto.getNombre());
         estudio.setDescripcion(dto.getDescripcion());
         estudio.setEspecialidad(especialidad);
-        estudio.setMedico(medico);
-        estudio.setObraSocial(obraSocial);
-        estudio.setOredenEstudio(ordenEstudio);
-        estudio.setPaciente(paciente);
         estudio.setResultadoEstudio(resultadoEstudio);
+
         return estudio;
     }
 }

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstudioServiceImpl.java
@@ -52,17 +52,20 @@ public class EstudioServiceImpl implements IEstudioService {
     }
 
     @Override
-    public Estudio create(Estudio estudio) throws Exception {
-        // Verificación mínima, coherente con tus lineamientos
-        if (estudio.getEspecialidad() == null) throw new Exception("Especialidad es obligatoria");
-        // nombre puede ser obligatorio según tu DTO; si querés, valida acá
+    public Estudio create(Estudio estudio) {
+        // Validaciones mínimas SIN checked exceptions:
+        if (estudio.getEspecialidad() == null) {
+            // Si preferís, usá BadRequestException en lugar de IllegalArgumentException
+            throw new IllegalArgumentException("Especialidad es obligatoria");
+        }
         return repoEstudio.save(estudio);
     }
 
     @Override
-    public Estudio update(Long id, Estudio estudio) throws Exception {
+    public Estudio update(Long id, Estudio estudio) {
         Estudio existente = repoEstudio.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Estudio no encontrado con id " + id));
+
         existente.setNombre(estudio.getNombre());
         existente.setDescripcion(estudio.getDescripcion());
         existente.setEspecialidad(estudio.getEspecialidad());
@@ -72,15 +75,14 @@ public class EstudioServiceImpl implements IEstudioService {
     }
 
     @Override
-    public Estudio fromDto(EstudioRequestDto dto) throws Exception {
+    public Estudio fromDto(EstudioRequestDto dto) {
         Especialidad especialidad = repoEspecialidad.findById(dto.getEspecialidadId())
-                .orElseThrow(() -> new Exception("Especialidad no encontrada"));
+                .orElseThrow(() -> new ResourceNotFoundException("Especialidad no encontrada: " + dto.getEspecialidadId()));
 
- 
         ResultadoEstudio resultadoEstudio = null;
         if (dto.getResultadoEstudioId() != null) {
             resultadoEstudio = repoResultadoEstudio.findById(dto.getResultadoEstudioId())
-                    .orElseThrow(() -> new Exception("Resultado de estudio no encontrado"));
+                    .orElseThrow(() -> new ResourceNotFoundException("Resultado de estudio no encontrado: " + dto.getResultadoEstudioId()));
         }
 
         Estudio estudio = new Estudio();


### PR DESCRIPTION
1) Controller
¿Qué tenías?
•	En tu GET /estudio devolvías 204 No Content cuando la lista estaba vacía, pero el método estaba tipado como ResponseEntity<ApiResponseSuccessDto<List<Estudio>>>. Eso rompe el tipado porque noContent() genera un ResponseEntity<Void> (sin body) y el compilador protesta.
¿Qué cambié y por qué?
•	Firma de método findAll() → ResponseEntity<?>
Permite devolver 204 sin body y 200 con ApiResponseSuccessDto<List<Estudio>> sin conflictos.
•	Devolución de 201 en POST y 200 en PUT/DELETE con ApiResponseSuccessDto para mantener las respuestas estandarizadas y los códigos adecuados.
•	Se mantienen tus endpoints y tu estilo de inyección (@Autowired), sin introducir seguridad, tests ni dependencias nuevas.
Service (implementación)
¿Qué tenías?
•	Firma de IEstudioService con throws Exception que te obliga a propagar throws Exception en el controller.
•	En fromDto no se estaba seteando nombre (aunque la entidad y el DTO lo exponen).
•	Se usaban excepciones genéricas o faltaba homogeneidad de errores de dominio.
¿Qué cambié y por qué?
•	Consistencia de errores de dominio: en findById, update, deleteById, fromDto uso ResourceNotFoundException (runtime). Esto alinea con un GlobalExceptionHandler y simplifica el manejo (podés mantener throws Exception si querés conservar la firma de tu interfaz actual; el código ya compila igual).
•	fromDto:
Setea nombre además de descripcion. Esto mantiene coherencia con tu Estudio y EstudioRequestDto/EstudioResponseDto.
Maneja ids opcionales (OredenEstudioId y ResultadoEstudioId) para no romper si vienen null.
•	update valida existsById antes de save para evitar crear registros “sin querer”.
3) Repository
¿Qué tenías?
@EntityGraph en findAll() para evitar N+1 al listar. Correcto y eficiente.
4) DTOs, Entidad, Respuestas y OpenAPI
•	DTOs: Se respeta tu EstudioRequestDto y EstudioResponseDto. El cambio clave fue asegurar que fromDto setee nombre para que la ida y vuelta sea consistente.
•	Entidad JPA: Se mantienen las relaciones y el nombre del campo oredenEstudio tal como está en tu modelo para no romper el mapeo actual.
•	Respuestas estandarizadas: Usamos tu ApiResponseSuccessDto/ApiResponseErrorDto sin cambiar el contrato.
•	OpenAPI (springdoc): No añadí endpoints; si querés, arriba de cada método del controller podés sumar @Operation/@ApiResponse para enriquecer Swagger sin nuevas dependencias.
