### PR TITLE
Add NivelMateria DTOs, entity and mapper

### DIFF
--- a/src/main/java/com/imb2025/calificaciones/dto/request/NivelMateriaRequestDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/request/NivelMateriaRequestDto.java
@@ -1,0 +1,42 @@
+package com.imb2025.calificaciones.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Representa la carga de datos necesaria para crear o actualizar un nivel de materia.
+ */
+public class NivelMateriaRequestDto {
+
+    @NotBlank(message = "El nombre del nivel es obligatorio")
+    @Size(max = 100, message = "El nombre no puede superar los 100 caracteres")
+    private String nombre;
+
+    @NotBlank(message = "La descripción del nivel es obligatoria")
+    @Size(max = 255, message = "La descripción no puede superar los 255 caracteres")
+    private String descripcion;
+
+    public NivelMateriaRequestDto() {
+    }
+
+    public NivelMateriaRequestDto(String nombre, String descripcion) {
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/dto/response/NivelMateriaResponseDto.java
+++ b/src/main/java/com/imb2025/calificaciones/dto/response/NivelMateriaResponseDto.java
@@ -1,0 +1,54 @@
+package com.imb2025.calificaciones.dto.response;
+
+/**
+ * Representa la vista resumida de un nivel de materia disponible en el sistema.
+ */
+public class NivelMateriaResponseDto {
+
+    private Long id;
+    private String nombre;
+    private String descripcion;
+    private Long version;
+
+    public NivelMateriaResponseDto() {
+    }
+
+    public NivelMateriaResponseDto(Long id, String nombre, String descripcion, Long version) {
+        this.id = id;
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.version = version;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/entity/NivelMateria.java
+++ b/src/main/java/com/imb2025/calificaciones/entity/NivelMateria.java
@@ -1,0 +1,77 @@
+package com.imb2025.calificaciones.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+/**
+ * Entidad JPA que representa el nivel o dificultad asignado a una materia.
+ */
+@Entity
+@Table(name = "niveles_materia")
+public class NivelMateria {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String nombre;
+
+    @Column(nullable = false, length = 255)
+    private String descripcion;
+
+    @Version
+    private Long version;
+
+    public NivelMateria() {
+    }
+
+    public NivelMateria(String nombre, String descripcion) {
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+    }
+
+    public NivelMateria(Long id, String nombre, String descripcion, Long version) {
+        this.id = id;
+        this.nombre = nombre;
+        this.descripcion = descripcion;
+        this.version = version;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/src/main/java/com/imb2025/calificaciones/mapper/NivelMateriaMapper.java
+++ b/src/main/java/com/imb2025/calificaciones/mapper/NivelMateriaMapper.java
@@ -1,0 +1,43 @@
+package com.imb2025.calificaciones.mapper;
+
+import com.imb2025.calificaciones.dto.request.NivelMateriaRequestDto;
+import com.imb2025.calificaciones.dto.response.NivelMateriaResponseDto;
+import com.imb2025.calificaciones.entity.NivelMateria;
+
+/**
+ * Conversión explícita entre entidades {@link NivelMateria} y sus DTO asociados.
+ */
+public final class NivelMateriaMapper {
+
+    private NivelMateriaMapper() {
+    }
+
+    public static NivelMateria toEntity(NivelMateriaRequestDto requestDto) {
+        if (requestDto == null) {
+            return null;
+        }
+        NivelMateria entity = new NivelMateria();
+        entity.setNombre(requestDto.getNombre());
+        entity.setDescripcion(requestDto.getDescripcion());
+        return entity;
+    }
+
+    public static void updateEntity(NivelMateria entity, NivelMateriaRequestDto requestDto) {
+        if (entity == null || requestDto == null) {
+            return;
+        }
+        entity.setNombre(requestDto.getNombre());
+        entity.setDescripcion(requestDto.getDescripcion());
+    }
+
+    public static NivelMateriaResponseDto toResponse(NivelMateria entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new NivelMateriaResponseDto(
+                entity.getId(),
+                entity.getNombre(),
+                entity.getDescripcion(),
+                entity.getVersion());
+    }
+}


### PR DESCRIPTION
## Summary
- add request and response DTOs for the NivelMateria feature
- define the NivelMateria JPA entity with an optimistic locking version field
- implement a mapper that converts between the entity and its DTOs

## Testing
- `./mvnw -q -DskipTests package` *(fails: repository download blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ecfebcce60832fad686b1507096501