### PR TITLE
Clean up unused imports and warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
         <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>3.3.1</version>
             <configuration>
                 <encoding>UTF-8</encoding>
             </configuration>

--- a/src/main/java/com/imb2025/smedico/controller/ConsultorioController.java
+++ b/src/main/java/com/imb2025/smedico/controller/ConsultorioController.java
@@ -5,7 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;

--- a/src/main/java/com/imb2025/smedico/controller/PacienteController.java
+++ b/src/main/java/com/imb2025/smedico/controller/PacienteController.java
@@ -29,10 +29,9 @@ public class PacienteController {
     public ResponseEntity<ApiResponseSuccessDto<List<PacienteResponseDto>>> findAllPacientes() {
         List<Paciente> lista = service.findAll();
         List<PacienteResponseDto> listaResponse = new ArrayList<>();
-        PacienteMapper mapper = new PacienteMapper();
 
         for (Paciente p : lista) {
-            PacienteResponseDto dto = mapper.toResponseDto(p);
+            PacienteResponseDto dto = PacienteMapper.toResponseDto(p);
             listaResponse.add(dto);
         }
 
@@ -49,8 +48,7 @@ public class PacienteController {
     @GetMapping("/{id}")
     public ResponseEntity<ApiResponseSuccessDto<PacienteResponseDto>> findPacienteById(@PathVariable("id") Long id) {
         Paciente paciente = service.findById(id);
-        PacienteMapper mapper = new PacienteMapper();
-        PacienteResponseDto dto = mapper.toResponseDto(paciente);
+        PacienteResponseDto dto = PacienteMapper.toResponseDto(paciente);
 
         ApiResponseSuccessDto<PacienteResponseDto> resp = new ApiResponseSuccessDto<>(
                 true,
@@ -65,11 +63,9 @@ public class PacienteController {
     @PostMapping
     public ResponseEntity<ApiResponseSuccessDto<PacienteResponseDto>> create(
             @Valid @RequestBody PacienteRequestDto dto) {
-
-        PacienteMapper mapper = new PacienteMapper();
-        Paciente entidad = mapper.fromDto(dto);
+        Paciente entidad = PacienteMapper.fromDto(dto);
         Paciente nuevo = service.create(entidad);
-        PacienteResponseDto responseDto = mapper.toResponseDto(nuevo);
+        PacienteResponseDto responseDto = PacienteMapper.toResponseDto(nuevo);
 
         ApiResponseSuccessDto<PacienteResponseDto> resp = new ApiResponseSuccessDto<>(
                 true,
@@ -85,11 +81,9 @@ public class PacienteController {
     public ResponseEntity<ApiResponseSuccessDto<PacienteResponseDto>> update(
             @PathVariable("id") Long id,
             @Valid @RequestBody PacienteRequestDto dto) {
-
-        PacienteMapper mapper = new PacienteMapper();
-        Paciente entidad = mapper.fromDto(dto);
+        Paciente entidad = PacienteMapper.fromDto(dto);
         Paciente actualizado = service.update(id, entidad);
-        PacienteResponseDto responseDto = mapper.toResponseDto(actualizado);
+        PacienteResponseDto responseDto = PacienteMapper.toResponseDto(actualizado);
 
         ApiResponseSuccessDto<PacienteResponseDto> resp = new ApiResponseSuccessDto<>(
                 true,
@@ -118,11 +112,10 @@ public class PacienteController {
     @GetMapping("/porapellido")
     public ResponseEntity<ApiResponseSuccessDto<List<PacienteResponseDto>>> getPacientesOrdenados() {
         List<Paciente> lista = service.findAllOrder();
-        PacienteMapper mapper = new PacienteMapper();
         List<PacienteResponseDto> listaResponse = new ArrayList<>();
 
         for (Paciente p : lista) {
-            listaResponse.add(mapper.toResponseDto(p));
+            listaResponse.add(PacienteMapper.toResponseDto(p));
         }
 
         ApiResponseSuccessDto<List<PacienteResponseDto>> resp = new ApiResponseSuccessDto<>(
@@ -138,11 +131,10 @@ public class PacienteController {
     @GetMapping("/dni/{numeroDni}")
     public ResponseEntity<ApiResponseSuccessDto<List<PacienteResponseDto>>> getPacienteByDni(@PathVariable String numeroDni) {
         List<Paciente> lista = service.findByDni(numeroDni);
-        PacienteMapper mapper = new PacienteMapper();
         List<PacienteResponseDto> listaResponse = new ArrayList<>();
 
         for (Paciente p : lista) {
-            listaResponse.add(mapper.toResponseDto(p));
+            listaResponse.add(PacienteMapper.toResponseDto(p));
         }
 
         ApiResponseSuccessDto<List<PacienteResponseDto>> resp = new ApiResponseSuccessDto<>(
@@ -158,11 +150,10 @@ public class PacienteController {
     @GetMapping("/domain/{domainValue}")
     public ResponseEntity<ApiResponseSuccessDto<List<PacienteResponseDto>>> getPacienteByDomainEmail(@PathVariable String domainValue) {
         List<Paciente> lista = service.findByDomainEmail(domainValue);
-        PacienteMapper mapper = new PacienteMapper();
         List<PacienteResponseDto> listaResponse = new ArrayList<>();
 
         for (Paciente p : lista) {
-            listaResponse.add(mapper.toResponseDto(p));
+            listaResponse.add(PacienteMapper.toResponseDto(p));
         }
 
         ApiResponseSuccessDto<List<PacienteResponseDto>> resp = new ApiResponseSuccessDto<>(

--- a/src/main/java/com/imb2025/smedico/controller/RecetaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/RecetaController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.imb2025.smedico.service.IPacienteService;
 import com.imb2025.smedico.service.IRecetaService;
 
 import jakarta.validation.Valid;
@@ -24,7 +23,6 @@ import jakarta.validation.Valid;
 import com.imb2025.smedico.dto.ApiResponseSuccessDto;
 import com.imb2025.smedico.dto.request.RecetaRequestDto;
 import com.imb2025.smedico.dto.response.RecetaResponseDto;
-import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.entity.Receta;
 import com.imb2025.smedico.mapper.RecetaMapper;
 

--- a/src/main/java/com/imb2025/smedico/dto/mapper/ConsultaMapper.java
+++ b/src/main/java/com/imb2025/smedico/dto/mapper/ConsultaMapper.java
@@ -3,7 +3,6 @@ package com.imb2025.smedico.dto.mapper;
 import com.imb2025.smedico.dto.request.ConsultaRequestDto;
 import com.imb2025.smedico.dto.response.ConsultaResponseDto;
 import com.imb2025.smedico.entity.Consulta;
-import com.imb2025.smedico.entity.Turno;
 public final class ConsultaMapper {
     private ConsultaMapper() {}
 

--- a/src/main/java/com/imb2025/smedico/dto/mapper/SignosVitalesMapper.java
+++ b/src/main/java/com/imb2025/smedico/dto/mapper/SignosVitalesMapper.java
@@ -43,22 +43,22 @@ public class SignosVitalesMapper {
 	        }
 	    }
 	    
-	    return new SignosVitalesResponseDto(
-	    		
-	        s.getId(),
-	        s.getFechaHora(),
-	        s.getPeso(),
-	        s.getAltura(),
-	        s.getImc(),
-	        s.getTemperatura(),
-	        s.getFrecuenciaCardiaca(),
-	        s.getPresionSistolica(),
-	        s.getPresionDiastolica(),
-	        s.getSaturacionO2(),
-	        s.getObservaciones(),
-	        s.getConsulta().getId(),
-	        s.getVersion()
-	    );
-	}
+        return new SignosVitalesResponseDto(
+
+                s.getId(),
+                s.getFechaHora(),
+                s.getPeso(),
+                s.getAltura(),
+                s.getImc(),
+                s.getTemperatura(),
+                s.getFrecuenciaCardiaca(),
+                s.getPresionSistolica(),
+                s.getPresionDiastolica(),
+                s.getSaturacionO2(),
+                s.getObservaciones(),
+                idConsulta,
+                s.getVersion()
+            );
+        }
 
 }

--- a/src/main/java/com/imb2025/smedico/dto/request/ResultadoEstudioRequestDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/request/ResultadoEstudioRequestDto.java
@@ -1,7 +1,6 @@
 package com.imb2025.smedico.dto.request;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/imb2025/smedico/dto/response/FacturaResponseDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/response/FacturaResponseDto.java
@@ -2,7 +2,6 @@ package com.imb2025.smedico.dto.response;
 
 import com.imb2025.smedico.entity.MedioPago;
 import com.imb2025.smedico.entity.Paciente;
-import jakarta.persistence.ManyToOne;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/imb2025/smedico/dto/response/PacienteResponseDto.java
+++ b/src/main/java/com/imb2025/smedico/dto/response/PacienteResponseDto.java
@@ -1,7 +1,5 @@
 package com.imb2025.smedico.dto.response;
 
-import com.imb2025.smedico.entity.Paciente;
-
 public class PacienteResponseDto {
 
     private Long id; 

--- a/src/main/java/com/imb2025/smedico/entity/Especialidad.java
+++ b/src/main/java/com/imb2025/smedico/entity/Especialidad.java
@@ -1,9 +1,6 @@
 package com.imb2025.smedico.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 @Entity
 public class Especialidad extends BaseEntity{

--- a/src/main/java/com/imb2025/smedico/entity/HabitacionPaciente.java
+++ b/src/main/java/com/imb2025/smedico/entity/HabitacionPaciente.java
@@ -2,10 +2,6 @@ package com.imb2025.smedico.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "habitaciones_paciente")

--- a/src/main/java/com/imb2025/smedico/entity/Medico.java
+++ b/src/main/java/com/imb2025/smedico/entity/Medico.java
@@ -1,9 +1,6 @@
 package com.imb2025.smedico.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 

--- a/src/main/java/com/imb2025/smedico/entity/MedioPago.java
+++ b/src/main/java/com/imb2025/smedico/entity/MedioPago.java
@@ -8,9 +8,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
 @Entity

--- a/src/main/java/com/imb2025/smedico/entity/MotivoCancelacion.java
+++ b/src/main/java/com/imb2025/smedico/entity/MotivoCancelacion.java
@@ -1,9 +1,6 @@
 package com.imb2025.smedico.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 @Entity

--- a/src/main/java/com/imb2025/smedico/entity/Paciente.java
+++ b/src/main/java/com/imb2025/smedico/entity/Paciente.java
@@ -1,9 +1,6 @@
 package com.imb2025.smedico.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import java.time.LocalDate;
 
 @Entity

--- a/src/main/java/com/imb2025/smedico/entity/Receta.java
+++ b/src/main/java/com/imb2025/smedico/entity/Receta.java
@@ -1,9 +1,7 @@
 package com.imb2025.smedico.entity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDate;

--- a/src/main/java/com/imb2025/smedico/exception/EstadoTurnoNotFoundException.java
+++ b/src/main/java/com/imb2025/smedico/exception/EstadoTurnoNotFoundException.java
@@ -4,6 +4,7 @@ package com.imb2025.smedico.exception;
  * Excepción personalizada para indicar que un EstadoTurno no existe.
  */
 public class EstadoTurnoNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
 
     public EstadoTurnoNotFoundException(String message) {
         super(message);

--- a/src/main/java/com/imb2025/smedico/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/imb2025/smedico/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.exception;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -9,7 +8,6 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.core.annotation.Order;
-import org.springframework.dao.DataIntegrityViolationException; // CHANGE: para 409
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;

--- a/src/main/java/com/imb2025/smedico/exception/PacienteExpcepcion.java
+++ b/src/main/java/com/imb2025/smedico/exception/PacienteExpcepcion.java
@@ -1,7 +1,9 @@
 package com.imb2025.smedico.exception;
 
 public class PacienteExpcepcion extends RuntimeException {
-	 public PacienteExpcepcion (String mensaje) {
-	        super(mensaje);
-	    }
+    private static final long serialVersionUID = 1L;
+
+    public PacienteExpcepcion(String mensaje) {
+        super(mensaje);
+    }
 }

--- a/src/main/java/com/imb2025/smedico/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/imb2025/smedico/exception/ResourceNotFoundException.java
@@ -1,6 +1,8 @@
 package com.imb2025.smedico.exception;
 
 public class ResourceNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     public ResourceNotFoundException(String message) {
         super(message);
     }

--- a/src/main/java/com/imb2025/smedico/mapper/OrdenEstudioMapper.java
+++ b/src/main/java/com/imb2025/smedico/mapper/OrdenEstudioMapper.java
@@ -9,7 +9,6 @@ import com.imb2025.smedico.entity.Medico;
 import com.imb2025.smedico.entity.OrdenEstudio;
 import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.EspecialidadRepository;
 import com.imb2025.smedico.repository.EstudioRepository;
 import com.imb2025.smedico.repository.MedicoRepository;
 import com.imb2025.smedico.repository.PacienteRepository;

--- a/src/main/java/com/imb2025/smedico/mapper/RecetaMapper.java
+++ b/src/main/java/com/imb2025/smedico/mapper/RecetaMapper.java
@@ -1,7 +1,6 @@
 package com.imb2025.smedico.mapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.repository.CrudRepository;
 
 import com.imb2025.smedico.dto.request.RecetaRequestDto;
 import com.imb2025.smedico.dto.response.RecetaResponseDto;

--- a/src/main/java/com/imb2025/smedico/repository/RecetaRepository.java
+++ b/src/main/java/com/imb2025/smedico/repository/RecetaRepository.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.imb2025.smedico.entity.Medico;
-import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.entity.Receta;
 
 public interface RecetaRepository extends JpaRepository<Receta, Long> {

--- a/src/main/java/com/imb2025/smedico/service/IEspecialidadService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEspecialidadService.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.service;
 
-import com.imb2025.smedico.dto.request.EspecialidadRequestDto;
 import com.imb2025.smedico.entity.Especialidad;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 

--- a/src/main/java/com/imb2025/smedico/service/IEspecialidadService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEspecialidadService.java
@@ -1,8 +1,6 @@
 package com.imb2025.smedico.service;
 
 import com.imb2025.smedico.entity.Especialidad;
-import com.imb2025.smedico.exception.ResourceNotFoundException;
-
 import java.util.List;
 
 public interface IEspecialidadService {

--- a/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
+++ b/src/main/java/com/imb2025/smedico/service/IEstadoTurnoService.java
@@ -2,7 +2,6 @@ package com.imb2025.smedico.service;
 
 import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.dto.request.EstadoTurnoRequestDto; 
 
 import java.util.List;
 

--- a/src/main/java/com/imb2025/smedico/service/IMedicoService.java
+++ b/src/main/java/com/imb2025/smedico/service/IMedicoService.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.service;
 
-import com.imb2025.smedico.dto.request.MedicoRequestDto;
 import com.imb2025.smedico.entity.Medico;
 import java.util.List;
 

--- a/src/main/java/com/imb2025/smedico/service/IPacienteService.java
+++ b/src/main/java/com/imb2025/smedico/service/IPacienteService.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.service;
 
-import com.imb2025.smedico.dto.request.PacienteRequestDto;
 import com.imb2025.smedico.entity.Paciente;
 import java.util.List;
 

--- a/src/main/java/com/imb2025/smedico/service/IRecetaService.java
+++ b/src/main/java/com/imb2025/smedico/service/IRecetaService.java
@@ -1,8 +1,5 @@
 package com.imb2025.smedico.service;
 
-import com.imb2025.smedico.dto.request.RecetaRequestDto;
-import com.imb2025.smedico.entity.Medico;
-import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.entity.Receta;
 
 import java.time.LocalDate;

--- a/src/main/java/com/imb2025/smedico/service/IResultadoEstudioService.java
+++ b/src/main/java/com/imb2025/smedico/service/IResultadoEstudioService.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.service;
 
-import com.imb2025.smedico.dto.request.ResultadoEstudioRequestDto;
 import com.imb2025.smedico.entity.ResultadoEstudio;
 
 import java.time.LocalDate;

--- a/src/main/java/com/imb2025/smedico/service/ISignosVitalesService.java
+++ b/src/main/java/com/imb2025/smedico/service/ISignosVitalesService.java
@@ -3,8 +3,6 @@ package com.imb2025.smedico.service;
 import java.time.LocalDate;
 import java.util.List;
 
-import com.imb2025.smedico.dto.request.SignosVitalesRequestDto;
-import com.imb2025.smedico.entity.Consulta;
 import com.imb2025.smedico.entity.SignosVitales;
 
 public interface ISignosVitalesService {

--- a/src/main/java/com/imb2025/smedico/service/jpa/DetalleRecetaServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/DetalleRecetaServiceImpl.java
@@ -5,8 +5,6 @@ import com.imb2025.smedico.dto.request.DetalleRecetaRequestDto;
 import com.imb2025.smedico.dto.response.DetalleRecetaResponseDto;
 import com.imb2025.smedico.dto.mapper.DetalleRecetaMapper;
 import com.imb2025.smedico.entity.DetalleReceta;
-import com.imb2025.smedico.entity.Medicamento;
-import com.imb2025.smedico.entity.Receta;
 import com.imb2025.smedico.repository.DetalleRecetaRepository;
 import com.imb2025.smedico.repository.MedicamentoRepository;
 import com.imb2025.smedico.repository.RecetaRepository;

--- a/src/main/java/com/imb2025/smedico/service/jpa/EspecialidadServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EspecialidadServiceImpl.java
@@ -1,12 +1,10 @@
  package com.imb2025.smedico.service.jpa;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.request.EspecialidadRequestDto;
 import com.imb2025.smedico.entity.Especialidad;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.repository.EspecialidadRepository;

--- a/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/EstadoTurnoServiceImpl.java
@@ -1,7 +1,6 @@
 package com.imb2025.smedico.service.jpa;
 
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.mapper.EstadoTurnoMapper; // Importamos el Mapper
 
 import java.util.List;
 
@@ -10,18 +9,15 @@ import org.springframework.stereotype.Service;
 import com.imb2025.smedico.entity.EstadoTurno;
 import com.imb2025.smedico.repository.EstadoTurnoRepository;
 import com.imb2025.smedico.service.IEstadoTurnoService;
-import com.imb2025.smedico.dto.request.EstadoTurnoRequestDto;
 
 @Service
 public class EstadoTurnoServiceImpl implements IEstadoTurnoService {
 
     private final EstadoTurnoRepository estadoTurnoRepository;
-    private final EstadoTurnoMapper mapper; 
 
     // Constructor con inyección de dependencias
-    public EstadoTurnoServiceImpl(EstadoTurnoRepository estadoTurnoRepository, EstadoTurnoMapper mapper) {
+    public EstadoTurnoServiceImpl(EstadoTurnoRepository estadoTurnoRepository) {
         this.estadoTurnoRepository = estadoTurnoRepository;
-        this.mapper = mapper;
     }
 
     @Override

--- a/src/main/java/com/imb2025/smedico/service/jpa/FacturaServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/FacturaServiceImpl.java
@@ -3,8 +3,6 @@ package com.imb2025.smedico.service.jpa;
 import com.imb2025.smedico.entity.Factura;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.repository.FacturaRepository;
-import com.imb2025.smedico.repository.MedioPagoRepository;
-import com.imb2025.smedico.repository.PacienteRepository;
 import com.imb2025.smedico.service.IFacturaService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +44,7 @@ public class FacturaServiceImpl implements IFacturaService {
 
     @Override
     public void deleteById(Long id) {
-        Factura existente = facturaRepository.findById(id)
+        facturaRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Factura con ID: " + id + " no encontrada"));
         facturaRepository.deleteById(id);
     }

--- a/src/main/java/com/imb2025/smedico/service/jpa/MedicoServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/MedicoServiceImpl.java
@@ -6,9 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.imb2025.smedico.entity.Medico;
-import com.imb2025.smedico.dto.request.MedicoRequestDto;
-import com.imb2025.smedico.entity.Especialidad;
-import com.imb2025.smedico.repository.EspecialidadRepository;
 import com.imb2025.smedico.repository.MedicoRepository;
 import com.imb2025.smedico.service.IMedicoService;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
@@ -18,9 +15,6 @@ public class MedicoServiceImpl implements IMedicoService {
 
     @Autowired
     private MedicoRepository repo;
-
-    @Autowired
-    private EspecialidadRepository repoEspecialidad;
 
     @Override
     public List<Medico> findAll() {

--- a/src/main/java/com/imb2025/smedico/service/jpa/MotivoCancelacionServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/MotivoCancelacionServiceImpl.java
@@ -1,12 +1,10 @@
 package com.imb2025.smedico.service.jpa;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.request.MotivoCancelacionRequestDto;
 import com.imb2025.smedico.entity.MotivoCancelacion;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.repository.MotivoCancelacionRepository;

--- a/src/main/java/com/imb2025/smedico/service/jpa/OrdenEstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/OrdenEstudioServiceImpl.java
@@ -6,16 +6,10 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.request.OrdenEstudioRequestDto;
-import com.imb2025.smedico.entity.Estudio;
 import com.imb2025.smedico.entity.Medico;
 import com.imb2025.smedico.entity.OrdenEstudio;
-import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.EstudioRepository;
-import com.imb2025.smedico.repository.MedicoRepository;
 import com.imb2025.smedico.repository.OrdenEstudioRepository;
-import com.imb2025.smedico.repository.PacienteRepository;
 import com.imb2025.smedico.service.IOrdenEstudioService;
 
 @Service
@@ -24,15 +18,6 @@ public class OrdenEstudioServiceImpl implements IOrdenEstudioService{
 	@Autowired
 	private OrdenEstudioRepository repo;
 
-	@Autowired
-	private MedicoRepository medicoRepository;
-
-	@Autowired
-	private PacienteRepository pacienteRepository;
-	
-	@Autowired
-	private EstudioRepository estudioRepository;
-	
 	@Override
 	public List<OrdenEstudio> findAll() {
 		return repo.findAll();

--- a/src/main/java/com/imb2025/smedico/service/jpa/PacienteServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/PacienteServiceImpl.java
@@ -1,6 +1,5 @@
 package com.imb2025.smedico.service.jpa;
 
-import com.imb2025.smedico.dto.request.PacienteRequestDto;
 import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.repository.PacienteRepository;

--- a/src/main/java/com/imb2025/smedico/service/jpa/RecetaServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/RecetaServiceImpl.java
@@ -1,18 +1,12 @@
 package com.imb2025.smedico.service.jpa;
 
-import com.imb2025.smedico.dto.request.RecetaRequestDto;
-import com.imb2025.smedico.entity.Medico;
-import com.imb2025.smedico.entity.Paciente;
 import com.imb2025.smedico.entity.Receta;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.MedicoRepository;
-import com.imb2025.smedico.repository.PacienteRepository;
 import com.imb2025.smedico.repository.RecetaRepository;
 import com.imb2025.smedico.service.IRecetaService;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -22,12 +16,6 @@ public class RecetaServiceImpl implements IRecetaService {
 
     @Autowired
     private RecetaRepository repo;
-
-    @Autowired
-    private MedicoRepository medicoRepository;
-
-    @Autowired
-    private PacienteRepository pacienteRepository;
 
     @Override
     public List<Receta> findAll() {

--- a/src/main/java/com/imb2025/smedico/service/jpa/ResultadoEstudioServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/ResultadoEstudioServiceImpl.java
@@ -1,12 +1,7 @@
 package com.imb2025.smedico.service.jpa;
 
-import com.imb2025.smedico.dto.request.ResultadoEstudioRequestDto;
-import com.imb2025.smedico.entity.Estudio;
-import com.imb2025.smedico.entity.OrdenEstudio;
 import com.imb2025.smedico.entity.ResultadoEstudio;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
-import com.imb2025.smedico.repository.EstudioRepository;
-import com.imb2025.smedico.repository.OrdenEstudioRepository;
 import com.imb2025.smedico.repository.ResultadoEstudioRepository;
 import com.imb2025.smedico.service.IResultadoEstudioService;
 
@@ -22,12 +17,6 @@ public class ResultadoEstudioServiceImpl implements IResultadoEstudioService {
 	
 	@Autowired
 	private ResultadoEstudioRepository repo;
-	
-	@Autowired
-	private OrdenEstudioRepository ordenEstudioRepository;
-	
-	@Autowired
-	private EstudioRepository estudioRepository;
 	
 	@Override
 	public List<ResultadoEstudio> findAll() {

--- a/src/main/java/com/imb2025/smedico/service/jpa/SignosVitalesServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/SignosVitalesServiceImpl.java
@@ -8,8 +8,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import com.imb2025.smedico.dto.mapper.SignosVitalesMapper;
-import com.imb2025.smedico.dto.request.SignosVitalesRequestDto;
 import com.imb2025.smedico.entity.Consulta;
 import com.imb2025.smedico.entity.SignosVitales;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
@@ -25,9 +23,6 @@ public class SignosVitalesServiceImpl implements ISignosVitalesService {
 
     @Autowired
     private IConsultaService consultaService;
-    
-    SignosVitalesMapper mapper = new SignosVitalesMapper();
-
     @Override
     public List<SignosVitales> findAll() {
         return signos.findAll();


### PR DESCRIPTION
## Summary
- remove unused imports and fields throughout services, controllers, repositories, DTOs, entities and mappers to clear IDE warnings
- add missing `serialVersionUID` declarations for custom exceptions and fix mapping logic that previously triggered warnings
- update `PacienteController` and `SignosVitalesMapper` to use static mapper methods correctly, ensuring no more static access warnings

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download Maven due to network restrictions in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919ff03cce8832fa0395726d84d33a9)