### PR TITLE
Reubicar mappers a com.imb2025.smedico.mapper y ajustar inyección con @Autowired

### DIFF
--- a/src/main/java/com/imb2025/smedico/controller/ConsultaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/ConsultaController.java
@@ -15,7 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.imb2025.smedico.dto.ApiResponseSuccessDto;
-import com.imb2025.smedico.dto.mapper.ConsultaMapper;
+import com.imb2025.smedico.mapper.ConsultaMapper;
 import com.imb2025.smedico.dto.request.ConsultaRequestDto;
 import com.imb2025.smedico.dto.response.ConsultaResponseDto;
 import com.imb2025.smedico.entity.Consulta;

--- a/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
+++ b/src/main/java/com/imb2025/smedico/controller/EncuestaController.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 
 import jakarta.validation.Valid;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,13 +22,11 @@ import com.imb2025.smedico.mapper.EncuestaMapper;
 @RequestMapping("/api/encuestas")
 public class EncuestaController {
 
-    private  IEncuestaService service;
-    private  EncuestaMapper mapper;
+    @Autowired
+    private IEncuestaService service;
 
-    public EncuestaController(IEncuestaService service, EncuestaMapper mapper) {
-        this.service = service;
-        this.mapper = mapper;
-    }
+    @Autowired
+    private EncuestaMapper mapper;
 
     @GetMapping
     public ResponseEntity<ApiResponseSuccessDto<List<EncuestaResponseDto>>> findAll() {

--- a/src/main/java/com/imb2025/smedico/controller/SignosVitalesController.java
+++ b/src/main/java/com/imb2025/smedico/controller/SignosVitalesController.java
@@ -10,7 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import com.imb2025.smedico.dto.ApiResponseSuccessDto;
-import com.imb2025.smedico.dto.mapper.SignosVitalesMapper;
+import com.imb2025.smedico.mapper.SignosVitalesMapper;
 import com.imb2025.smedico.dto.request.SignosVitalesRequestDto;
 import com.imb2025.smedico.dto.response.SignosVitalesResponseDto;
 import com.imb2025.smedico.entity.SignosVitales;
@@ -25,7 +25,8 @@ public class SignosVitalesController {
 	@Autowired
 	private ISignosVitalesService service;
 	
-	SignosVitalesMapper mapper = new SignosVitalesMapper();
+	@Autowired
+	private SignosVitalesMapper mapper;
 
 	@GetMapping
 	public ResponseEntity<?> getAllSignosVitales() {

--- a/src/main/java/com/imb2025/smedico/mapper/ConsultaMapper.java
+++ b/src/main/java/com/imb2025/smedico/mapper/ConsultaMapper.java
@@ -1,4 +1,4 @@
-package com.imb2025.smedico.dto.mapper;
+package com.imb2025.smedico.mapper;
 
 import com.imb2025.smedico.dto.request.ConsultaRequestDto;
 import com.imb2025.smedico.dto.response.ConsultaResponseDto;

--- a/src/main/java/com/imb2025/smedico/mapper/DetalleRecetaMapper.java
+++ b/src/main/java/com/imb2025/smedico/mapper/DetalleRecetaMapper.java
@@ -1,4 +1,4 @@
-package com.imb2025.smedico.dto.mapper;
+package com.imb2025.smedico.mapper;
 
 import com.imb2025.smedico.dto.request.DetalleRecetaRequestDto;
 import com.imb2025.smedico.dto.response.DetalleRecetaResponseDto;

--- a/src/main/java/com/imb2025/smedico/mapper/SignosVitalesMapper.java
+++ b/src/main/java/com/imb2025/smedico/mapper/SignosVitalesMapper.java
@@ -1,10 +1,12 @@
-package com.imb2025.smedico.dto.mapper;
+package com.imb2025.smedico.mapper;
 
 import com.imb2025.smedico.dto.request.SignosVitalesRequestDto;
 import com.imb2025.smedico.dto.response.SignosVitalesResponseDto;
 import com.imb2025.smedico.entity.Consulta;
 import com.imb2025.smedico.entity.SignosVitales;
+import org.springframework.stereotype.Component;
 
+@Component
 public class SignosVitalesMapper {
 
 	public SignosVitales fromDto(SignosVitalesRequestDto dto) {

--- a/src/main/java/com/imb2025/smedico/service/jpa/DetalleRecetaServiceImpl.java
+++ b/src/main/java/com/imb2025/smedico/service/jpa/DetalleRecetaServiceImpl.java
@@ -3,7 +3,7 @@ package com.imb2025.smedico.service.jpa;
 import com.imb2025.smedico.exception.ResourceNotFoundException;
 import com.imb2025.smedico.dto.request.DetalleRecetaRequestDto;
 import com.imb2025.smedico.dto.response.DetalleRecetaResponseDto;
-import com.imb2025.smedico.dto.mapper.DetalleRecetaMapper;
+import com.imb2025.smedico.mapper.DetalleRecetaMapper;
 import com.imb2025.smedico.entity.DetalleReceta;
 import com.imb2025.smedico.repository.DetalleRecetaRepository;
 import com.imb2025.smedico.repository.MedicamentoRepository;


### PR DESCRIPTION
### Motivation

- Resolver la excepción de arranque causada por la ausencia de beans de mapper moviendo los mappers fuera del paquete `com.imb2025.smedico.dto.mapper` hacia `com.imb2025.smedico.mapper` para que Spring los detecte correctamente.
- Normalizar la inyección de dependencias usando `@Autowired` en controladores/servicios donde los mappers son consumidos.

### Description

- Movidos los archivos `ConsultaMapper`, `DetalleRecetaMapper` y `SignosVitalesMapper` desde `com.imb2025.smedico.dto.mapper` a `com.imb2025.smedico.mapper` y actualizados sus `package` declarations.
- Actualizados los imports afectados en `ConsultaController`, `SignosVitalesController` y `DetalleRecetaServiceImpl` para apuntar a `com.imb2025.smedico.mapper`.
- Convertido el uso del mapper en `SignosVitalesController` a una inyección `@Autowired` y marcado `SignosVitalesMapper` con `@Component` para que Spring lo registre como bean.
- Cambiada la inyección en `EncuestaController` para usar campos inyectados con `@Autowired` en lugar del constructor que recibía el mapper, y eliminado el paquete `dto.mapper` vacío.

### Testing

- Ejecuté la compilación con `./mvnw -q -DskipTests compile` para validar cambios de compilación, pero la ejecución falló por un error de descarga de Maven (`wget: Failed to fetch https://repo.maven.apache.org/...`) en este entorno.
- No se ejecutaron tests unitarios automatizados adicionales en este entorno (no se pudieron completar por la falla de la descarga de dependencias).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acf5888c8832fb1f5c02ab62d1302)